### PR TITLE
docs: la forma del registry generico di strategy (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,16 +20,28 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   density, che si costruisce con due posizionali.
 
   A decidere non e' stato il gusto ma due vincoli esterni, entrambi scritti
-  nella doc: le mappe di modulo sono superficie che il test di parita' di
-  PGE-ls importa per nome (#246), e i test di qui le trattano gia' come
+  nella doc. Il primo: cinque nomi di modulo — le quattro mappe voce e
+  `CHORD_INTERVALS` — sono superficie che il test di parita' di PGE-ls importa
+  dal motore per nome. Cinque, non tutti: delle altre quattro mappe, dei
+  `register_*`, delle `Factory` e di `SEMITONE_LOCKED` PGE-ls tiene specchi
+  scritti a mano, e la #246 inventaria l'esposizione di PGE-ui, dove nessuna di
+  queste mappe compare. Il secondo: i test di qui le trattano gia' come
   dizionari (`isinstance`, `clear()`/`update()`, `del`, `pop`) — con delle
   closure il dizionario resterebbe comunque fuori, cioe' si riscriverebbe la
-  duplicazione spostata di due righe. Da cui anche il buco che il refactor
-  *apre* e che #184 deve chiudere: la guardia della #187 riconosce le `def
-  register_*_strategy` di livello modulo, e un `log_strategy_registration`
-  spostato dentro un metodo della classe generica le esce dal campo visivo —
-  la stessa lezione del settimo entry point in `contratto-stdout.md`, un giro
-  piu' in la'.
+  duplicazione spostata di due righe.
+
+  Da cui anche i due buchi che il refactor *apre* e che #184 deve chiudere. La
+  guardia della #187 riconosce le `def register_*_strategy` di livello modulo, e
+  un `log_strategy_registration` spostato dentro un metodo della classe generica
+  le esce dal campo visivo — la stessa lezione del settimo entry point in
+  `contratto-stdout.md`, un giro piu' in la'. E l'ordine degli errori della
+  facade di density e' pinnato da `tests/strategies/test_registry_errors.py`:
+  con nome ignoto *e* `distribution` assente e' l'ordine a decidere il tipo
+  dell'eccezione, quindi il lookup va interrogato prima della validazione di
+  dominio. Lo scheletro porta infine `from __future__ import annotations`, e non
+  per ornamento: `Dict[str, Type[S]] | None` e' un'annotazione di firma,
+  valutata alla `def`, e sulla 3.9 che `pyproject.toml` dichiara un PEP 604
+  valutato fa fallire l'import del modulo — il difetto pagato dalla #257.
 
 - **La guardia sugli `except` di `cli.py` copre anche cio' che il blocco della
   pipeline non contiene** (issue #257). La guardia strutturale leggeva i `try`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- **`docs/explanation/strategy-registry.md`** — la forma decisa del registry
+  generico di strategy (issue #177): decisione, non esecuzione (quella e'
+  #184 e #185). Lo schema duplicato sta in **otto** moduli, non sei — il
+  criterio e' la forma, non la cartella `strategies/` — e la forma scelta e'
+  una classe che *e'* la mappa (`StrategyRegistry(Dict[str, Type[S]])`), con
+  `strategy_kind` alla costruzione e `create(name, *args, **kwargs)` che non
+  guarda dentro gli argomenti: e' cio' che fa entrare dalla stessa porta la
+  density, che si costruisce con due posizionali.
+
+  A decidere non e' stato il gusto ma due vincoli esterni, entrambi scritti
+  nella doc: le mappe di modulo sono superficie che il test di parita' di
+  PGE-ls importa per nome (#246), e i test di qui le trattano gia' come
+  dizionari (`isinstance`, `clear()`/`update()`, `del`, `pop`) — con delle
+  closure il dizionario resterebbe comunque fuori, cioe' si riscriverebbe la
+  duplicazione spostata di due righe. Da cui anche il buco che il refactor
+  *apre* e che #184 deve chiudere: la guardia della #187 riconosce le `def
+  register_*_strategy` di livello modulo, e un `log_strategy_registration`
+  spostato dentro un metodo della classe generica le esce dal campo visivo —
+  la stessa lezione del settimo entry point in `contratto-stdout.md`, un giro
+  piu' in la'.
+
 - **La guardia sugli `except` di `cli.py` copre anche cio' che il blocco della
   pipeline non contiene** (issue #257). La guardia strutturale leggeva i `try`
   che *contengono* `load_yaml()`, ed era la lettura giusta per il difetto che

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -22,6 +22,7 @@
 | [multi-voice](explanation/multi-voice.md) | stable | voices, strategy, dmx-1000, granular |
 | [parameter-curve](explanation/parameter-curve.md) | stable | parameters, envelopes, architecture, refactor |
 | [score-visualizer-layout](explanation/score-visualizer-layout.md) | stable | rendering, visualizer, architecture, refactor, matplotlib |
+| [strategy-registry](explanation/strategy-registry.md) | stable | strategy, registry, refactor, estensibilita, architecture |
 | [supercollider-backend](explanation/supercollider-backend.md) | stable | renderer, supercollider, nrt, osc, architecture |
 
 ## How-to

--- a/docs/explanation/strategy-registry.md
+++ b/docs/explanation/strategy-registry.md
@@ -1,0 +1,368 @@
+---
+slug: strategy-registry
+type: explanation
+status: stable
+tags: [strategy, registry, refactor, estensibilita, architecture]
+sources:
+  - src/pge/strategies/voice_pitch_strategy.py
+  - src/pge/strategies/voice_onset_strategy.py
+  - src/pge/strategies/voice_pointer_strategy.py
+  - src/pge/strategies/voice_pan_strategy.py
+  - src/pge/strategies/strategy_registry.py
+  - src/pge/strategies/variation_registry.py
+  - src/pge/strategies/grain_clip_strategy.py
+  - src/pge/controllers/window_selection_strategy.py
+  - src/pge/shared/exceptions.py
+  - src/pge/shared/logger.py
+  - tests/shared/test_stdout_contract.py
+last_synced_commit: e44ede3
+---
+
+# Il registry generico delle strategy — la forma decisa
+
+**Documenti collegati:** [[INDEX]] · [[architecture]] · [[multi-voice]] · [[contratto-stdout]] · [[add-voice-strategy]] · [[add-variation-strategy]]
+
+Questo documento è l'esito della issue #177: la **decisione** su che forma prende
+il registry generico, non la sua esecuzione. L'esecuzione è #184 (tracer bullet)
+e #185 (le altre). Al commit qui sopra nessun modulo è ancora stato convertito:
+quel che segue descrive la forma verso cui convergere e, per ogni scelta, il
+vincolo che l'ha decisa.
+
+---
+
+## Problema
+
+Lo stesso schema — un dizionario di modulo, una `register_*()`, una classe
+`Factory` con un solo `create()` statico — è ripetuto in **otto** moduli, non
+sei. La #177 ne elenca sei perché guarda `strategies/`; il criterio però non è
+la cartella, è la forma:
+
+| modulo | mappa | registrazione | riga diagnostica | `create()` |
+|---|---|---|---|---|
+| `strategies/voice_pitch_strategy.py` | `VOICE_PITCH_STRATEGIES` | `(name, cls)` | no | `create(name, **kwargs)` |
+| `strategies/voice_onset_strategy.py` | `VOICE_ONSET_STRATEGIES` | `(name, cls)` | no | `create(name, **kwargs)` |
+| `strategies/voice_pointer_strategy.py` | `VOICE_POINTER_STRATEGIES` | `(name, cls)` | no | `create(name, **kwargs)` |
+| `strategies/voice_pan_strategy.py` | `VOICE_PAN_STRATEGIES` | `(name, strategy_class)` | sì, dominio `'pan voce'` | `create(strategy_name, **kwargs)` |
+| `strategies/strategy_registry.py` | `DENSITY_STRATEGIES` | `(param_name, strategy_class)` | sì, dominio `'density'` | `create_density_strategy(selected_param_name, param_obj, all_params)` |
+| `strategies/variation_registry.py` | `VARIATION_STRATEGIES` | `(mode_name, strategy_class)` | sì, dominio `'variation'` | `create(variation_mode)` |
+| `controllers/window_selection_strategy.py` | `WINDOW_STRATEGY_REGISTRY` | `(name, cls)` | no | `create(name, **kwargs)` + `from_spec(...)` |
+| `strategies/grain_clip_strategy.py` | `GRAIN_CLIP_STRATEGIES` | — | — | `create(name, **kwargs)` |
+
+La tabella è la prova che si tratta di duplicazione e non di somiglianza: per
+una cosa sola — «registra una classe sotto un nome» — ci sono tre parole per il
+primo parametro (`name`, `param_name`, `mode_name`), due per il secondo (`cls`,
+`strategy_class`), due convenzioni per il nome della mappa (`*_STRATEGIES` e
+`WINDOW_STRATEGY_REGISTRY`), tre etichette di dominio scritte a mano, e un
+ottavo registry che non ha nemmeno il punto di registrazione.
+
+**Un punto della #177 è già stato sciolto altrove, e conviene arrivarci
+sapendolo.** Il `print()` alla registrazione non esiste più: la #187 lo ha
+portato a `log_strategy_registration`, cioè al logger `pge.diagnostics`, e la
+regola di quale riga vive su stdout è scritta in [[contratto-stdout]]. Quel che
+resta della divergenza descritta dalla issue non è il canale, è **chi la riga la
+emette**: tre registry su otto la emettono, quattro tacciono, uno non ha la
+funzione da cui emetterla.
+
+Due vincoli esterni rendono questa duplicazione più cara di quanto sembri, e
+sono ciò che decide la forma più di ogni preferenza di stile:
+
+- **I nomi di modulo sono superficie pinnata.** Il test di parità di PGE-ls
+  importa `VOICE_PITCH_STRATEGIES`, `VOICE_ONSET_STRATEGIES`,
+  `VOICE_POINTER_STRATEGIES`, `VOICE_PAN_STRATEGIES` e `CHORD_INTERVALS` dai
+  moduli del motore e ne confronta le chiavi con il proprio registro statico:
+  spostare o rinominare una di quelle mappe rende rossa la CI di un altro
+  repository senza far fallire un test di PGE. È la stessa esposizione
+  inventariata dalla #246.
+- **La guardia sulla diagnostica è derivata dai sorgenti.**
+  `tests/shared/test_stdout_contract.py` cerca con `ast` le `def
+  register_*_strategy` di livello modulo, pretende che l'insieme dei moduli che
+  ne contengono una sia *esattamente* quello dichiarato, e che nessuna di quelle
+  funzioni stampi. Il refactor passa dentro quella guardia: una forma che
+  facesse sparire quelle `def` la spegnerebbe.
+
+## Modello
+
+### La forma
+
+Una classe generica che **è** la mappa, in un modulo nuovo
+`src/pge/strategies/registry.py`:
+
+```python
+S = TypeVar("S")
+
+
+class StrategyRegistry(Dict[str, Type[S]]):
+    """Mappa nome -> classe strategy che conosce il proprio dominio."""
+
+    def __init__(self, kind: str, base: Type[S],
+                 initial: Dict[str, Type[S]] | None = None):
+        super().__init__(initial or {})
+        self.kind = kind
+        self.base = base
+
+    def register(self, name: str, cls: Type[S]) -> None:
+        self[name] = cls
+        log_strategy_registration(self.kind, name, cls)
+
+    def create(self, name: str, *args, **kwargs) -> S:
+        if name not in self:
+            raise StrategyNotFoundError(
+                strategy_kind=self.kind,
+                name=name,
+                available=list(self.keys()),
+            )
+        return self[name](*args, **kwargs)
+```
+
+Ogni modulo conserva tre cose e nient'altro:
+
+```python
+VOICE_PAN_STRATEGIES = StrategyRegistry('voice_pan', VoicePanStrategy, {
+    'range': RangePanStrategy,
+    'stochastic': StochasticPanStrategy,
+    'step': StepPanStrategy,
+})
+
+
+def register_voice_pan_strategy(name, strategy_class):
+    """<docstring con l'esempio di estensione, invariata>"""
+    VOICE_PAN_STRATEGIES.register(name, strategy_class)
+
+
+class VoicePanStrategyFactory:
+    @staticmethod
+    def create(name: str, **kwargs) -> VoicePanStrategy:
+        return VOICE_PAN_STRATEGIES.create(name, **kwargs)
+```
+
+### Perché una classe e non funzioni di modulo che chiudono su un dizionario
+
+È la domanda 1 della #177, e a deciderla non è il gusto: è che **il dizionario
+deve restare raggiungibile e mutabile sotto il suo nome di modulo**. I test di
+oggi lo trattano come tale — `isinstance(registry, dict)`, `dict(registry)` per
+lo snapshot della fixture, `registry.clear()` e `registry.update()` per il
+ripristino, `del registry[k]` e `registry.pop(k, None)` per il cleanup — e la
+parità di PGE-ls ne legge le chiavi. Con delle closure il dizionario resterebbe
+comunque fuori, esposto e separato dalle funzioni che lo governano: si
+riscriverebbe la duplicazione di oggi, spostata di due righe. Una classe che
+eredita da `dict` è invece un solo oggetto che soddisfa tutta quella superficie
+e in più sa il proprio dominio.
+
+Lo scheletro qui sopra è stato **misurato** contro quei vincoli fuori albero,
+non solo argomentato: `isinstance(..., dict)`, il giro
+`dict()`/`clear()`/`update()` della fixture di pan, `del`/`pop`, la riga
+diagnostica che arriva a `pge.diagnostics` e non a stdout,
+`StrategyNotFoundError` con `strategy_kind`/`name`/`available`, e le tre forme
+di costruzione (`**kwargs` per pan, due posizionali per density, nessun
+argomento per variation). Il codice che li misura vive in #184, dove diventa
+test.
+
+### `strategy_kind` alla costruzione (domanda 2)
+
+Alla costruzione. Il `kind` non è un dato della chiamata, è una proprietà del
+registry: `create()` non ha modo di sbagliarlo e nessun chiamante deve
+ripeterlo. Quel valore è già quello che `StrategyNotFoundError` riporta oggi
+(`voice_pan`, `density`, `variation`, …), quindi **i messaggi d'errore non
+cambiano** — verificato che nessuno, in PGE-ui o PGE-ls, li parsi.
+
+Lo stesso `kind` diventa anche il dominio della riga diagnostica, e questo
+uniforma le tre etichette scritte a mano: `'pan voce'` diventa `voice_pan`. Il
+test che oggi la sorveglia chiede `'pan' in messaggio`, quindi resta verde; la
+docstring di `log_strategy_registration`, che cita `'pan voce'` come esempio, va
+aggiornata insieme.
+
+### `create(name, *args, **kwargs)`
+
+Il registry **non guarda dentro gli argomenti**: li inoltra al costruttore così
+come arrivano. I posizionali non sono un lusso: le due strategy di density si
+costruiscono con `(param, distribution_param)` e chiamano quel primo parametro
+con due nomi diversi (`fill_factor_param`, `density_param`), quindi per parola
+chiave non si passano affatto. Con `*args` la density entra dalla stessa porta
+delle altre invece di avere un `create` proprio, che è esattamente il caso
+speciale che la #184 vieta di aggiungere.
+
+Il primo parametro si chiama `name` ovunque. `strategy_name` (pan) e
+`variation_mode` (variation) descrivono da dove viene il valore, non che cosa è:
+è la chiave del registry. Tutti i chiamanti di oggi lo passano posizionalmente
+— in `Stream`, in `Parameter`, nei test — quindi la convergenza non rompe
+niente.
+
+### `base` è portato, non imposto
+
+Il registry riceve l'ABC del proprio dominio: serve a inferire il tipo di
+ritorno di `create()` e a rendere l'oggetto autodescrittivo. **Non** verifica
+`issubclass` alla registrazione: sarebbe un rifiuto nuovo, e un rifiuto nuovo è
+un cambio di superficie pubblica — chi oggi registra una strategy duck-typed
+smetterebbe di poterlo fare. Se lo si vuole, è una issue sua, con la sua analisi
+d'impatto, non un effetto collaterale del refactor.
+
+### Le costanti restano dove sono (domanda 3)
+
+`SEMITONE_LOCKED` e `CHORD_INTERVALS` restano nomi di modulo in
+`voice_pitch_strategy.py`, fuori dal registry. Due ragioni, e la seconda è più
+forte della prima:
+
+1. non sono contenuto del registry. `SEMITONE_LOCKED` è un'affermazione sulle
+   *unità*, indicizzata per nome di strategy e letta da
+   `Stream._init_voice_manager`; `CHORD_INTERVALS` è il dominio di un kwarg.
+   Attaccarle all'oggetto registry darebbe alla classe generica una superficie
+   per dominio, cioè il caso speciale;
+2. `CHORD_INTERVALS` è importata dal test di parità di PGE-ls e da
+   `diagnostic_provider.py`, `SEMITONE_LOCKED` da `Stream`. Spostarle costa una
+   CI rossa altrove in cambio di niente.
+
+Resta vero che `SEMITONE_LOCKED` è una lista di nomi che deve restare allineata
+alle chiavi del registry, e che una strategy registrata dinamicamente non può
+dichiararsi semitone-locked. La cura sarebbe metadato sulla classe, non sul
+registry: è materiale per la decomposizione di `Stream` (#190) e per il wiring
+(#186), non per qui.
+
+### Il `print()` (domanda 4)
+
+Già deciso dalla #178 e fatto dalla #187: logger diagnostico, mai stdout. La
+forma generica lo eredita in un punto solo — `StrategyRegistry.register` — con
+la conseguenza che **i quattro registry oggi muti cominciano a parlare** (pitch,
+onset, pointer, window). È voluto: è una riga `DEBUG` su un logger che di
+default non ha handler, quindi non compare a nessuno che non l'abbia accesa, e
+l'alternativa sarebbe conservare la divergenza per non toccarla.
+
+C'è però un buco che il refactor **apre**, e va chiuso nello stesso passo. La
+guardia della #187 riconosce le `def register_*_strategy` di livello modulo: il
+`log_strategy_registration` che si sposta dentro un *metodo* di
+`StrategyRegistry` esce dal suo campo visivo, e da lì una `print()` potrebbe
+rientrare lasciando la suite verde. È la stessa lezione del settimo entry point
+in [[contratto-stdout]] — il criterio è la funzione, non la cartella — un giro
+più in là: la guardia deve imparare anche `StrategyRegistry.register`, e le
+`def register_*_strategy` devono restare `def` di modulo (una riga di corpo che
+delega), non alias `register_x = REGISTRY.register`. Un alias farebbe sparire
+quel modulo dal censimento dei sorgenti: il test lo direbbe subito, ma la
+decisione è che i wrapper restino, perché sono l'API di estensione documentata e
+portano le proprie docstring con gli esempi.
+
+### density e variation entrano, le loro façade no (domanda 5)
+
+Entrano per **archiviazione, lookup ed errore**: sono un dizionario nome →
+classe con lo stesso `StrategyNotFoundError`, e la differenza di dominio
+(density, variation) è esattamente ciò che il `kind` alla costruzione esiste per
+portare.
+
+Non entra la loro logica di dominio. `StrategyFactory.create_density_strategy`
+tiene la propria firma e la propria validazione: cerca `distribution` fra i
+parametri e solleva `InvalidStrategyConfigError` se manca. Quello non è lookup,
+è una regola su come si costruisce una strategy di density — e la sua firma è
+pinnata anche in dettaglio, con un test che pretende che
+`StrategyFactory.__dict__['create_density_strategy']` sia uno `staticmethod`.
+Per la stessa ragione tutte le façade restano `@staticmethod` che delegano, non
+alias di metodo legato.
+
+### Chi fa da tracer bullet
+
+`voice_pan_strategy`, come dice la #184 — ma non più per le ragioni scritte lì,
+e vale la pena dirlo perché quelle ragioni sono invecchiate: non è più «l'unica
+il cui `register_*()` stampa su stdout» (nessuna stampa più dalla #187). Regge
+lo stesso, per tre motivi:
+
+- è l'unica il cui `create()` chiama il primo parametro `strategy_name`, cioè
+  l'unica dove la convergenza su `name` si misura davvero;
+- è una delle tre che emettono la riga diagnostica, quindi passa per il punto
+  dove il dominio si uniforma (`'pan voce'` → `voice_pan`);
+- i suoi test sono quelli che maltrattano di più la mappa —
+  `isinstance(..., dict)`, snapshot e ripristino con `clear()`/`update()`,
+  `pop()` nel `finally` — cioè sono la verifica che la classe generica soddisfi
+  la superficie `dict` che tutti danno per scontata.
+
+Se per farla passare servisse un caso speciale nella classe generica, la regola
+è quella della #184: si torna qui e si cambia la forma, non si aggiunge
+l'eccezione.
+
+### Chi resta fuori
+
+`InterpolationStrategyFactory` (`envelopes/envelope_factory.py`) **non** entra:
+la sua mappa è privata, normalizza il nome (`strip().lower()`), accetta in
+ingresso anche un'istanza già costruita e solleva `ValueError` invece di
+`StrategyNotFoundError`. È un adattatore, non un registry, e uniformarlo
+significherebbe cambiare cosa accetta — un'altra decisione, con un altro
+impatto.
+
+`window_selection_strategy` e `grain_clip_strategy` invece **rientrano**, ma
+dopo: sono il seguito di #185, non parte di #184/#185, così che il tracer bullet
+resti misurato su un modulo solo. La prima porta anche `from_spec()`, che è
+lettura di YAML e resta sua; il secondo non ha punto di registrazione e la
+conversione è l'occasione per decidere se debba averlo.
+
+## Trade-off
+
+**Ereditare da `dict` è un compromesso, ed è quello che i vincoli scelgono.**
+La forma più pulita — composizione, la mappa privata dietro un'interfaccia
+stretta — è preclusa da ciò che i test e la parità di PGE-ls già trattano come
+un dizionario. Il costo si paga in due punti: `registry.copy()` restituisce un
+`dict` normale, che non ha né `kind` né `create()` (chi vuole un registry lo
+costruisce, chi vuole uno snapshot ha quel che gli serve); e `registry['x'] =
+cls` resta una registrazione legale e muta, che scavalca la riga diagnostica.
+Il secondo è voluto: la riga appartiene al punto di ingresso esplicito, e la
+scrittura diretta è quel che fanno le fixture per rimettere a posto lo stato.
+
+**La riga diagnostica passa da tre registry a otto.** Uniformare vuol dire
+anche estendere, non solo togliere. Su un canale spento di default il prezzo è
+nullo a runtime; il prezzo vero è che d'ora in poi «registrare» e «annunciare la
+registrazione» sono la stessa operazione e non si possono più separare per
+registry — che è precisamente quel che si voleva.
+
+**Il risparmio in righe è modesto.** Otto copie di una ventina di righe
+diventano una classe di trenta più otto superfici sottili: il conto netto è
+piccolo, e chi cerca lì il guadagno resterà deluso. Il guadagno è che la
+prossima divergenza ha un posto solo dove succedere, e che la prossima domanda
+(«questo registry valida? logga? come si chiama il primo parametro?») ha una
+risposta sola.
+
+**Il refactor tocca moduli che un altro repository importa per nome.** Ogni
+nome di livello modulo — le otto mappe, i sette `register_*`, le sette
+`Factory` — sopravvive identico, e non è un riguardo estetico: è la condizione
+perché la parità di PGE-ls resti verde (#246). Chi esegue #184/#185 lo verifichi
+prima di rinominare qualcosa, non dopo.
+
+**La documentazione di estensione è già disallineata, e questo la rimette in
+riga.** [[add-voice-strategy]] dice «registra nella factory
+`Voice<Axis>StrategyFactory.REGISTRY`» e [[add-variation-strategy]] dice
+`VariationFactory.REGISTRY`: quell'attributo non è mai esistito. La forma decisa
+qui non lo introduce — la mappa vive a livello di modulo, dove i test e PGE-ls
+la cercano — quindi le due how-to vanno corrette nel passo che le tocca, non
+prese come specifica.
+
+## Implicazioni codice
+
+- **Aggiungi una strategy a un asse esistente** → `register_<asse>_strategy(nome,
+  Classe)`, che delega a `REGISTRY.register`. La mappa di modulo resta il posto
+  dove si guarda cosa è registrato.
+- **Aggiungi un asse o un registry nuovo** → `StrategyRegistry('<kind>', ABC,
+  {...})` al livello di modulo, più una `def register_<kind>_strategy` che
+  delega, più il modulo in `MODULI_CON_REGISTRAZIONE_DINAMICA` di
+  `tests/shared/test_stdout_contract.py`. Il `kind` è la stessa stringa che
+  compare in `StrategyNotFoundError`.
+- **Non trasformare i `register_*` in alias** di `REGISTRY.register`: la guardia
+  della diagnostica cerca `def register_*_strategy` di livello modulo, e un
+  alias fa uscire il modulo dal censimento.
+- **Non spostare né rinominare** le mappe di modulo, i `register_*`, le
+  `Factory`, `SEMITONE_LOCKED`, `CHORD_INTERVALS`: sono superficie che PGE-ls
+  importa (#246). Se una deve muoversi, prima l'analisi d'impatto cross-repo.
+- **Non aggiungere validazione `issubclass`** dentro `register()` in #184/#185:
+  è un rifiuto nuovo e va introdotto da una issue sua.
+- **Ordine di esecuzione** → #184 (pan, con la guardia estesa a
+  `StrategyRegistry.register`), poi #185 (pitch, onset, pointer, density,
+  variation), poi un seguito per `window_selection_strategy` e
+  `grain_clip_strategy`.
+- **Se il tracer bullet chiede un'eccezione** → si torna a questo documento e si
+  cambia la forma. Un caso speciale nella classe generica è il segnale che la
+  forma è sbagliata, non che il modulo è strano.
+
+## Vedi anche
+
+- [[contratto-stdout]] — perché la conferma di registrazione è diagnostica e non
+  stdout, e perché il criterio di una guardia è la funzione e non la cartella
+- [[multi-voice]] — gli assi che i quattro registry voce servono
+- [[architecture]] — l'Open/Closed che i registry realizzano
+- [[add-voice-strategy]] · [[add-variation-strategy]] — le how-to che questa
+  decisione obbliga a correggere
+- Issue #177 (questa decisione), #184 (tracer bullet), #185 (le altre cinque),
+  #187 e #178 (il canale della riga di registrazione), #246 (la superficie
+  interna pinnata da PGE-ui e PGE-ls)

--- a/docs/explanation/strategy-registry.md
+++ b/docs/explanation/strategy-registry.md
@@ -76,7 +76,9 @@ sono ciò che decide la forma più di ogni preferenza di stile:
   `VOICE_POINTER_STRATEGIES`, `VOICE_PAN_STRATEGIES` e `CHORD_INTERVALS`, e ne
   confronta le chiavi con il proprio registro statico: spostare o rinominare
   una di quelle cinque rende rossa la CI di un altro repository senza far
-  fallire un test di PGE. Le altre quattro mappe (density, variation, window,
+  fallire un test di PGE — quando quella CI il motore ce l'ha, perché il
+  checkout è condizionato a un secret e senza di esso la parità skippa in
+  verde (#269). Le altre quattro mappe (density, variation, window,
   grain_clip) nessuno le importa da fuori, e nemmeno i `register_*`, le
   `Factory` o `SEMITONE_LOCKED` — di quest'ultima PGE-ls tiene una copia a mano
   (`SEMITONE_LOCKED_STRATEGIES` in `granular_ls/pitch_units.py`), che un rename
@@ -84,7 +86,8 @@ sono ciò che decide la forma più di ogni preferenza di stile:
   È la stessa *classe* di esposizione che inventaria la #246, non la stessa
   esposizione — quell'issue elenca ciò che importa l'harness di parità di
   **PGE-ui**, e fra i suoi moduli non compare nessuna di queste mappe. Il
-  vincolo PGE-ls, oggi, non è registrato altrove che qui.
+  censimento dell'esposizione PGE-ls, che al momento di scrivere questa
+  decisione non esisteva, è la #269.
 - **La guardia sulla diagnostica è derivata dai sorgenti.**
   `tests/shared/test_stdout_contract.py` cerca con `ast` le `def
   register_*_strategy` di livello modulo, pretende che l'insieme dei moduli che
@@ -370,9 +373,9 @@ registrazione) — sopravvive identico. Per cinque di quei nomi, e cinque soli, 
 la condizione perché la parità di PGE-ls resti verde: le quattro mappe voce e
 `CHORD_INTERVALS`. Per tutti gli altri è disciplina interna, non vincolo
 esterno, e conviene saperlo in questi termini: chi esegue #184/#185 deve
-verificare *quali* nomi sono davvero pinnati, e il posto dove leggerlo è il
-censimento qui sopra — non la #246, che inventaria la superficie importata da
-**PGE-ui** e non nomina nessuna di queste mappe.
+verificare *quali* nomi sono davvero pinnati, e il posto dove leggerlo è la
+#269 (o il censimento qui sopra) — non la #246, che inventaria la superficie
+importata da **PGE-ui** e non nomina nessuna di queste mappe.
 
 **La documentazione di estensione è già disallineata, e questo la rimette in
 riga.** [[add-voice-strategy]] dice «registra nella factory
@@ -398,8 +401,8 @@ prese come specifica.
 - **Non spostare né rinominare** le mappe di modulo, i `register_*`, le
   `Factory`, `SEMITONE_LOCKED`, `CHORD_INTERVALS` — ma sapendo quanto costa
   ciascuno. `VOICE_PITCH/ONSET/POINTER/PAN_STRATEGIES` e `CHORD_INTERVALS` sono
-  importati per nome dal test di parità di PGE-ls: lì il costo è immediato e
-  fuori da qui. Gli altri costano dentro (`SEMITONE_LOCKED` la legge `Stream`)
+  importati per nome dal test di parità di PGE-ls (#269): lì il costo è
+  immediato e fuori da qui. Gli altri costano dentro (`SEMITONE_LOCKED` la legge `Stream`)
   o non costano ancora niente, e restano fermi per non spendere una decisione su
   niente. Se uno deve muoversi, prima l'analisi d'impatto cross-repo.
 - **Non aggiungere validazione `issubclass`** dentro `register()` in #184/#185:
@@ -421,6 +424,7 @@ prese come specifica.
 - [[add-voice-strategy]] · [[add-variation-strategy]] — le how-to che questa
   decisione obbliga a correggere
 - Issue #177 (questa decisione), #184 (tracer bullet), #185 (le altre cinque),
-  #187 e #178 (il canale della riga di registrazione), #246 (la superficie
-  interna pinnata da PGE-ui: stessa classe di vincolo, altro elenco — quello
-  di PGE-ls è censito qui)
+  #187 e #178 (il canale della riga di registrazione), #269 (la superficie
+  interna pinnata da PGE-ls: i cinque nomi di cui sopra, e perché il loro
+  presidio può tacere), #246 (la gemella per PGE-ui: stessa classe di
+  vincolo, altro elenco)

--- a/docs/explanation/strategy-registry.md
+++ b/docs/explanation/strategy-registry.md
@@ -12,9 +12,13 @@ sources:
   - src/pge/strategies/variation_registry.py
   - src/pge/strategies/grain_clip_strategy.py
   - src/pge/controllers/window_selection_strategy.py
+  - src/pge/envelopes/envelope_factory.py
+  - src/pge/core/stream.py
+  - src/pge/parameters/parameter.py
   - src/pge/shared/exceptions.py
   - src/pge/shared/logger.py
   - tests/shared/test_stdout_contract.py
+  - tests/strategies/test_registry_errors.py
 last_synced_commit: e44ede3
 ---
 
@@ -66,13 +70,21 @@ funzione da cui emetterla.
 Due vincoli esterni rendono questa duplicazione più cara di quanto sembri, e
 sono ciò che decide la forma più di ogni preferenza di stile:
 
-- **I nomi di modulo sono superficie pinnata.** Il test di parità di PGE-ls
-  importa `VOICE_PITCH_STRATEGIES`, `VOICE_ONSET_STRATEGIES`,
-  `VOICE_POINTER_STRATEGIES`, `VOICE_PAN_STRATEGIES` e `CHORD_INTERVALS` dai
-  moduli del motore e ne confronta le chiavi con il proprio registro statico:
-  spostare o rinominare una di quelle mappe rende rossa la CI di un altro
-  repository senza far fallire un test di PGE. È la stessa esposizione
-  inventariata dalla #246.
+- **Cinque nomi di modulo sono superficie pinnata, e solo cinque.**
+  `tests/test_pge_parity.py` di PGE-ls importa dai moduli del motore
+  `VOICE_PITCH_STRATEGIES`, `VOICE_ONSET_STRATEGIES`,
+  `VOICE_POINTER_STRATEGIES`, `VOICE_PAN_STRATEGIES` e `CHORD_INTERVALS`, e ne
+  confronta le chiavi con il proprio registro statico: spostare o rinominare
+  una di quelle cinque rende rossa la CI di un altro repository senza far
+  fallire un test di PGE. Le altre quattro mappe (density, variation, window,
+  grain_clip) nessuno le importa da fuori, e nemmeno i `register_*`, le
+  `Factory` o `SEMITONE_LOCKED` — di quest'ultima PGE-ls tiene una copia a mano
+  (`SEMITONE_LOCKED_STRATEGIES` in `granular_ls/pitch_units.py`), che un rename
+  qui per definizione non tocca: resta indietro in silenzio invece di gridare.
+  È la stessa *classe* di esposizione che inventaria la #246, non la stessa
+  esposizione — quell'issue elenca ciò che importa l'harness di parità di
+  **PGE-ui**, e fra i suoi moduli non compare nessuna di queste mappe. Il
+  vincolo PGE-ls, oggi, non è registrato altrove che qui.
 - **La guardia sulla diagnostica è derivata dai sorgenti.**
   `tests/shared/test_stdout_contract.py` cerca con `ast` le `def
   register_*_strategy` di livello modulo, pretende che l'insieme dei moduli che
@@ -88,6 +100,8 @@ Una classe generica che **è** la mappa, in un modulo nuovo
 `src/pge/strategies/registry.py`:
 
 ```python
+from __future__ import annotations
+
 S = TypeVar("S")
 
 
@@ -113,6 +127,19 @@ class StrategyRegistry(Dict[str, Type[S]]):
             )
         return self[name](*args, **kwargs)
 ```
+
+**La prima riga non è un ornamento**, ed è la ragione per cui sta nello
+scheletro invece di essere lasciata all'esecuzione: `Dict[str, Type[S]] | None`
+è un'annotazione di *firma*, quindi l'interprete la valuta alla `def`, e sulla
+3.9 — il minimo che `pyproject.toml` dichiara — un PEP 604 valutato alza
+`TypeError` in import. Il modulo non fallirebbe un test: smetterebbe di
+esistere, e con lui la classe che tutti gli altri importano. È il difetto che
+la #257 ha pagato per davvero e che ora `tests/test_minimum_python_syntax.py`
+sorveglia su `src/`; ogni modulo di `src/pge/` porta quell'import (misurato), e
+il nuovo non fa eccezione. La base `Dict[str, Type[S]]` invece non è
+un'annotazione e si valuta comunque: è legale sulla 3.9 perché viene da
+`typing`, e lo sarebbe anche scritta `dict[str, Type[S]]`, dato che PEP 585
+c'è dalla 3.9. Solo PEP 604 è il problema.
 
 Ogni modulo conserva tre cose e nient'altro:
 
@@ -207,9 +234,15 @@ forte della prima:
    `Stream._init_voice_manager`; `CHORD_INTERVALS` è il dominio di un kwarg.
    Attaccarle all'oggetto registry darebbe alla classe generica una superficie
    per dominio, cioè il caso speciale;
-2. `CHORD_INTERVALS` è importata dal test di parità di PGE-ls e da
-   `diagnostic_provider.py`, `SEMITONE_LOCKED` da `Stream`. Spostarle costa una
-   CI rossa altrove in cambio di niente.
+2. sono già lette da chi non può seguirle. `CHORD_INTERVALS` la importa dal
+   motore, per nome, il test di parità di PGE-ls (`tests/test_pge_parity.py`);
+   il `diagnostic_provider.py` di quel repo la nomina anche lui, ma legge il
+   proprio specchio in `granular_ls/voice_strategies.py`, quindi non è un
+   secondo vincolo — è una copia a mano, e la copia non protesta.
+   `SEMITONE_LOCKED` non esce da qui: la legge `Stream._init_voice_manager`, e
+   PGE-ls ne tiene un altro specchio (`SEMITONE_LOCKED_STRATEGIES`). Spostarle
+   costa una CI rossa — altrove per la prima, qui per la seconda — in cambio di
+   niente.
 
 Resta vero che `SEMITONE_LOCKED` è una lista di nomi che deve restare allineata
 alle chiavi del registry, e che una strategy registrata dinamicamente non può
@@ -255,6 +288,18 @@ pinnata anche in dettaglio, con un test che pretende che
 Per la stessa ragione tutte le façade restano `@staticmethod` che delegano, non
 alias di metodo legato.
 
+**Una cosa la façade non può delegare, e l'ordine in cui non la delega è
+pinnato.** `tests/strategies/test_registry_errors.py` chiama
+`create_density_strategy("bogus", None, {})` e pretende
+`StrategyNotFoundError`. Lì le due condizioni di fallimento sono vive insieme —
+il nome non è registrato *e* `distribution` manca — quindi è l'ordine a
+decidere il tipo dell'eccezione, e oggi il lookup viene prima. Una façade che
+delegasse il lookup a `DENSITY_STRATEGIES.create(...)` tenendo davanti la
+propria validazione solleverebbe `InvalidStrategyConfigError` e farebbe cadere
+quel test: il lookup va interrogato per primo (`name in REGISTRY` davanti al
+controllo di `distribution`) e solo la costruzione delegata al registry. È un
+vincolo per #185, non una preferenza.
+
 ### Chi fa da tracer bullet
 
 `voice_pan_strategy`, come dice la #184 — ma non più per le ragioni scritte lì,
@@ -262,8 +307,11 @@ e vale la pena dirlo perché quelle ragioni sono invecchiate: non è più «l'un
 il cui `register_*()` stampa su stdout» (nessuna stampa più dalla #187). Regge
 lo stesso, per tre motivi:
 
-- è l'unica il cui `create()` chiama il primo parametro `strategy_name`, cioè
-  l'unica dove la convergenza su `name` si misura davvero;
+- è l'unica il cui `create()` chiama il primo parametro `strategy_name` — non
+  l'unica a divergere da `name` (variation ha `variation_mode`, density
+  `selected_param_name`), ma l'unica in cui la divergenza cade sulla firma
+  `create(name, **kwargs)` che il registry generico deve assorbire tale e
+  quale, senza casi speciali;
 - è una delle tre che emettono la riga diagnostica, quindi passa per il punto
   dove il dominio si uniforma (`'pan voce'` → `voice_pan`);
 - i suoi test sono quelli che maltrattano di più la mappa —
@@ -316,10 +364,15 @@ prossima divergenza ha un posto solo dove succedere, e che la prossima domanda
 risposta sola.
 
 **Il refactor tocca moduli che un altro repository importa per nome.** Ogni
-nome di livello modulo — le otto mappe, i sette `register_*`, le sette
-`Factory` — sopravvive identico, e non è un riguardo estetico: è la condizione
-perché la parità di PGE-ls resti verde (#246). Chi esegue #184/#185 lo verifichi
-prima di rinominare qualcosa, non dopo.
+nome di livello modulo — le otto mappe, i sette `register_*`, le otto `Factory`
+(`grain_clip` compresa: la façade ce l'ha pur senza avere il punto di
+registrazione) — sopravvive identico. Per cinque di quei nomi, e cinque soli, è
+la condizione perché la parità di PGE-ls resti verde: le quattro mappe voce e
+`CHORD_INTERVALS`. Per tutti gli altri è disciplina interna, non vincolo
+esterno, e conviene saperlo in questi termini: chi esegue #184/#185 deve
+verificare *quali* nomi sono davvero pinnati, e il posto dove leggerlo è il
+censimento qui sopra — non la #246, che inventaria la superficie importata da
+**PGE-ui** e non nomina nessuna di queste mappe.
 
 **La documentazione di estensione è già disallineata, e questo la rimette in
 riga.** [[add-voice-strategy]] dice «registra nella factory
@@ -343,8 +396,12 @@ prese come specifica.
   della diagnostica cerca `def register_*_strategy` di livello modulo, e un
   alias fa uscire il modulo dal censimento.
 - **Non spostare né rinominare** le mappe di modulo, i `register_*`, le
-  `Factory`, `SEMITONE_LOCKED`, `CHORD_INTERVALS`: sono superficie che PGE-ls
-  importa (#246). Se una deve muoversi, prima l'analisi d'impatto cross-repo.
+  `Factory`, `SEMITONE_LOCKED`, `CHORD_INTERVALS` — ma sapendo quanto costa
+  ciascuno. `VOICE_PITCH/ONSET/POINTER/PAN_STRATEGIES` e `CHORD_INTERVALS` sono
+  importati per nome dal test di parità di PGE-ls: lì il costo è immediato e
+  fuori da qui. Gli altri costano dentro (`SEMITONE_LOCKED` la legge `Stream`)
+  o non costano ancora niente, e restano fermi per non spendere una decisione su
+  niente. Se uno deve muoversi, prima l'analisi d'impatto cross-repo.
 - **Non aggiungere validazione `issubclass`** dentro `register()` in #184/#185:
   è un rifiuto nuovo e va introdotto da una issue sua.
 - **Ordine di esecuzione** → #184 (pan, con la guardia estesa a
@@ -365,4 +422,5 @@ prese come specifica.
   decisione obbliga a correggere
 - Issue #177 (questa decisione), #184 (tracer bullet), #185 (le altre cinque),
   #187 e #178 (il canale della riga di registrazione), #246 (la superficie
-  interna pinnata da PGE-ui e PGE-ls)
+  interna pinnata da PGE-ui: stessa classe di vincolo, altro elenco — quello
+  di PGE-ls è censito qui)


### PR DESCRIPTION
Chiude #177, che chiede una **decisione scritta** e non l'esecuzione: quella e' #184 (tracer bullet su pan) e #185 (le altre cinque). Nessuna riga di `src/` toccata — la PR aggiunge `docs/explanation/strategy-registry.md`, la voce di CHANGELOG e la riga rigenerata in `docs/INDEX.md`.

## Cosa dice la decisione

**Il censimento corregge la premessa della issue in due punti.**

- I moduli con lo stesso schema sono **otto**, non sei: `controllers/window_selection_strategy.py` ha la stessa forma ma vive in un'altra cartella, e `strategies/grain_clip_strategy.py` ce l'ha senza avere nemmeno il punto di registrazione. Il criterio e' la forma, non `strategies/`.
- Il `print()` alla registrazione **non esiste piu'**: la #187 lo ha portato al logger diagnostico (vedi `contratto-stdout.md`). Cio' che resta della divergenza descritta dalla issue non e' il canale ma chi la riga la emette — tre registry su otto.

**La forma decisa** e' una classe che *e'* la mappa, `StrategyRegistry(Dict[str, Type[S]])` in `src/pge/strategies/registry.py`, con il dominio alla costruzione (`kind` come parametro, `strategy_kind` come parola chiave dell'errore) e `create(name, *args, **kwargs)` che inoltra gli argomenti senza guardarci dentro. I posizionali non sono un lusso: sono l'unico modo in cui la density entra dalla stessa porta delle altre, visto che le sue due strategy chiamano il primo parametro del costruttore con due nomi diversi (`fill_factor_param`, `density_param`). Ogni modulo conserva tre cose: il nome di modulo legato all'istanza, una `def register_*_strategy` che delega, la `Factory` come façade `@staticmethod`.

**A escludere le closure su un dizionario di modulo non e' il gusto, sono due vincoli esterni**, entrambi scritti nella doc:

- il test di parita' di PGE-ls importa `VOICE_*_STRATEGIES` e `CHORD_INTERVALS` dai moduli del motore per nome (#269);
- i test di qui trattano quelle mappe come dizionari: `isinstance(registry, dict)`, `dict(registry)` per lo snapshot della fixture, `clear()`/`update()` per il ripristino, `del` e `pop` per il cleanup.

Con delle closure il dizionario resterebbe comunque esposto e separato dalle funzioni che lo governano, cioe' si riscriverebbe la duplicazione di oggi spostata di due righe.

**Il presidio che il refactor indebolisce**, e che #184 deve rinforzare nello stesso passo: le guardie per `ast` della #187 sono **due**, e una sola perde di vista la classe generica. `test_la_registrazione_dinamica_non_stampa` riconosce le `def register_*_strategy` di livello modulo, e un `log_strategy_registration` spostato dentro un *metodo* le esce dal campo visivo; `test_le_strategie_non_stampano` e' pero' scoped per **cartella** e vieta qualunque `print()` in `strategies/*.py`, quindi copre gia' `strategies/registry.py` — il modulo che questa decisione sceglie — pur non sapendo niente di lei.

Misurato **sul modulo cablato**, non sullo scheletro che nessuno chiama: la stessa `print()` dentro `StrategyRegistry.register` fa cadere due test se la classe sta in `strategies/` e uno solo se sta in `shared/`. Fra le due collocazioni c'e' **un test di differenza**, non un rosso contro una suite verde. A parlare in entrambe e' una terza guardia che la #187 ha lasciato accanto a quelle per `ast`, ed e' *comportamentale*: i tre test che chiamano il vero `register_*_strategy` sotto `capsys` pretendendo `captured.out == ''` (pan, density, variation). Copertura incidentale pero' — percorre `register` e non `create`, vale finche' una delle tre resta cablata sulla classe, e non tocca i quattro registry che il refactor fa *cominciare* a parlare — mentre le guardie per `ast`, che sono quelle scritte apposta per sorvegliare questo, restano cieche alla classe in entrambe le collocazioni. Da cui la prescrizione: la guardia impari `StrategyRegistry.register`, cosi' che il presidio smetta di dipendere dalla cartella e dal caso; e i wrapper di modulo restino `def` e non diventino alias. E' la stessa lezione del settimo entry point in `contratto-stdout.md`, un giro piu' in la'.

Le altre risposte ai punti della issue (costanti che restano dove sono, density e variation dentro per lookup ed errore ma non per le loro façade, `voice_pan` confermata come tracer bullet con ragioni aggiornate) stanno nella doc.

## Verifica

- lo scheletro della classe e' stato **misurato** fuori albero contro i vincoli sopra prima di scriverlo come decisione: superficie `dict` (`isinstance`, il giro `dict()`/`clear()`/`update()`, `del`/`pop`, `copy()` che torna un `dict` nudo), riga diagnostica su `pge.diagnostics` a livello `DEBUG` e non su stdout, `StrategyNotFoundError` con `strategy_kind`/`name`/`available`, e le tre forme di costruzione (kwargs, due posizionali, nessun argomento). Il codice che li misura vive in #184, dove diventa test;
- il censimento (otto moduli, sette `register_*`, otto `Factory`, tre etichette di dominio, i nomi dei parametri, l'ordine lookup-prima-di-validazione in `create_density_strategy`, `SEMITONE_LOCKED` letta da `Stream._init_voice_manager`, `from __future__ import annotations` in **tutti e 91** i moduli di `src/pge/`) e' stato riverificato riga per riga sui sorgenti, anche dopo il merge di main;
- `make docs-lint` -> OK (24 docs), `make docs-index` rigenerato;
- `make tests` -> **6826 passed, 18 skipped** (era 6362/10 prima di merged main: i quattro moduli emitter della #202 e le loro suite).

## Giro di review (settembre)

Merge di `main` (#202/#263) nel branch — conflitto sul solo CHANGELOG, entrambe le voci tenute — e due correzioni alla doc:

- **il censimento grida, non tace.** «Problema» diceva che una forma capace di far sparire le `def register_*_strategy` «spegnerebbe» la guardia derivata dai sorgenti: e' il rovescio della proprieta' su cui la doc si appoggia piu' sotto. `test_la_lista_dei_punti_di_registrazione_e_completa` asserisce `trovati == dichiarati`, quindi diventa **rosso subito**; cio' che si spegne in silenzio e' la copertura, un passo dopo, quando si riallinea la lista per tornare verdi;
- **il banco di prova piu' largo non e' quello di pan.** La terza ragione del tracer bullet diceva che i test di pan sono «quelli che maltrattano di piu' la mappa». Misurato, e' falso: `tests/strategies/test_variation_registry.py` include per intero la superficie `dict` di pan e vi aggiunge `len()`, `values()` e l'iterazione di chiavi e `items()`. La ragione resta nella sua forma vera (i test di pan esercitano tutte le *forme* che la classe deve soddisfare) e accanto sta ora scritto chi misura la larghezza — una consegna per #185.

Riverificata invece come **corretta** la claim che sembrava piu' fragile: `assert 'pan' in messaggi[0]` esiste davvero, in `test_register_logs_instead_of_printing` (`tests/strategies/test_voice_pan_strategy.py`), passa per il vero `register_voice_pan_strategy`, e sopravvive a `'pan voce'` -> `voice_pan`.

## Secondo giro di review

Ricontrollata ogni affermazione della doc contro i sorgenti. Il censimento ha retto cella per cella (otto moduli, sette `register_*`, otto `Factory`, i nomi divergenti dei parametri, `create(strategy_name, …)` come unicum di pan), e cosi' i vincoli esterni: la parita' di PGE-ls importa esattamente quei cinque nomi e non le altre quattro mappe — il `WindowRegistry` che compare li' viene da `controllers/window_registry.py`, non e' `WINDOW_STRATEGY_REGISTRY` — i due specchi a mano esistono dove dichiarato, lo skip verde su secret assente e' reale, `.REGISTRY` non e' mai esistito e le due how-to lo nominano davvero, nessuno in PGE-ui o PGE-ls parsa i messaggi d'errore. Cinque correzioni:

- **la misura centrale era presa dove il difetto non puo' esistere.** «Lascia l'intera suite verde se sta altrove» valeva su uno scheletro *non cablato*. Rimisurato nello stato che la doc prescrive (pan costruita sulla classe, wrapper che delega): due test rossi in `strategies/`, uno in `shared/` — un test di differenza, e a parlare in entrambe sono i tre test comportamentali sotto `capsys` che la doc non contava. La prescrizione per #184 non cambia, si fa piu' precisa;
- **lo scheletro non portava nessuno dei suoi cinque import** (`Dict`, `Type`, `TypeVar`, `log_strategy_registration`, `StrategyNotFoundError`). Non e' contorno: il paragrafo sotto argomenta che la base e' legale sulla 3.9 «perche' viene da `typing`», e proprio quella riga mancava;
- **il titolo della domanda 2 annunciava `strategy_kind` alla costruzione**, ma il costruttore prende `kind`: `strategy_kind` e' la parola chiave dell'eccezione. Ora sono nominate entrambe;
- **`SEMITONE_LOCKED` e' un `frozenset`**, non «una lista», proprio nella frase che chiede resti allineato alle chiavi del registry;
- **«da tre registry a sette» e' il conto a convergenza avvenuta**, non quello di #184/#185: alla fine di #185 sono sei, perche' `window` sta nel seguito insieme a `grain_clip`. La sezione dichiarava il ritardo solo per l'ottavo.

Piu' l'ortografia delle tre righe aggiunte nel giro precedente (`e'`/`piu'`/`E'` in un file che altrove accenta). `make tests` verde prima di ogni commit.

## Impatto cross-repo

Nessuno: la PR non tocca superficie pubblica (YAML, errori, CLI, formati). Nessuna issue aperta su PGE-ls o PGE-ui. La doc *registra* pero' un vincolo per chi eseguira' #184/#185 — le mappe di modulo sono superficie che PGE-ls importa per nome — e li' l'analisi d'impatto va fatta prima di rinominare qualcosa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RY4QtGiCQbCnQXoYnjxdh