### PR TITLE
Accertamento completo del contratto stdout (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,45 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- **Il contratto di stdout e' accertato per intero, e sono due righe non una**
+  (issue #178). Fin qui il repo sorvegliava la sola `[CACHE] <id>: DIRTY|clean`
+  e per tutto il resto `api.py` diceva «nessuno le parsa, per quanto se ne sa».
+  Ora ognuna delle 64 `print()` di `src/pge/` ha una categoria — protocollo,
+  diagnostica, interfaccia CLI — e la categoria e' eseguibile:
+  `CLASSIFICAZIONE` in `tests/shared/test_stdout_contract.py` va confrontata
+  coi sorgenti nelle due direzioni, quindi una riga nuova senza categoria e una
+  categoria rimasta senza riga sono entrambe rosse.
+
+  **La seconda riga di protocollo non aveva nessuna guardia.** E' il blocco
+  riassuntivo di `cli.py`: sotto «Generazione completata!» ogni path esce
+  indentato di quattro spazi, e da li' PGE-ui ricava lo `stream-done`
+  dell'*ultimo* stream DIRTY del giro — gli altri li chiude la riga `[CACHE]`
+  successiva, l'ultimo non ha nessuna riga dopo di se'. Togliendole
+  l'indentazione la suite restava interamente verde e quell'unico stem prendeva
+  il pallino giallo dopo un render che aveva fatto esattamente cio' che il
+  pallino chiedeva. La guardia e' percio' di **comportamento** e non una
+  lettura `ast`: si fa scrivere alla CLI il suo riepilogo e si guardano i byte,
+  perche' un `print()` letto coi sorgenti direbbe che la riga esiste e solo
+  l'output dice che esce indentata.
+
+  **E stderr non e' il riparo che `logger.py` prometteva.** Il commento diceva
+  che la diagnostica e' al sicuro perche' la console di `logging` scrive su
+  stderr: vero sul file descriptor, falso sul canale che conta, perche' il
+  bridge di PGE-ui lancia il motore con `stderr=subprocess.STDOUT` e i due
+  flussi arrivano allo stesso parser. Con
+  `logging.basicConfig(level=DEBUG, format="%(message)s")` un record
+  diagnostico che cominci per `[CACHE] <token>: ` produce nell'editor uno
+  `stream-start` e uno `stream-done` per uno stream che non esiste. La regola
+  non e' quindi «il logger e' un altro canale», e' **nessuno, su nessun canale,
+  scrive righe con la forma del protocollo** — e ora c'e' una guardia anche sui
+  messaggi di logging, letti con `ast` come le `print()`.
+
+  Le guardie sulla forma chiedono **entrambe** le forme che
+  `render_pipeline.py` riconosce, non la sola `[CACHE]`: una
+  `print(f"    {x}")` nuova marcata interfaccia, o un `log.debug("    %s",
+  path)`, hanno la sagoma del blocco riassuntivo e chiudono in anticipo lo
+  stream in volo nell'editor.
+
 - **La guardia sugli `except` di `cli.py` copre anche cio' che il blocco della
   pipeline non contiene** (issue #257). La guardia strutturale leggeva i `try`
   che *contengono* `load_yaml()`, ed era la lettura giusta per il difetto che

--- a/docs/explanation/contratto-stdout.md
+++ b/docs/explanation/contratto-stdout.md
@@ -20,7 +20,7 @@ sources:
   - src/pge/rendering/score_visualizer.py
   - tests/shared/test_stdout_contract.py
   - tests/test_api_stdout.py
-last_synced_commit: 17a0d4f
+last_synced_commit: c33d153
 ---
 
 # Il contratto di stdout — protocollo, diagnostica, interfaccia
@@ -243,7 +243,11 @@ facendo scrivere alla CLI il suo riepilogo — un `print()` letto con `ast` dire
 che la riga esiste, solo i byte dicono che esce indentata); che ogni `print()`
 di `src/pge/` abbia una categoria e ogni categoria una `print()`; che nessuna
 riga non-protocollo abbia forma di protocollo; e che nessun **messaggio di
-log** ce l'abbia, perche' stderr non e' un riparo.
+log** ce l'abbia, perche' stderr non e' un riparo. Le ultime due chiedono
+**entrambe** le forme, non solo la `[CACHE]`: una `print(f"    {x}")` nuova e
+un `log.debug("    %s", path)` hanno la sagoma del blocco riassuntivo, cioe'
+chiudono nell'editor lo stream in volo, e guardare la sola `[CACHE]` li
+lasciava passare.
 
 **La tabella dice dove una riga sta, non dove dovrebbe andare.** Spostare
 un'INTERFACCIA al logger resta una scelta di prodotto: cambia cio' che l'utente
@@ -257,11 +261,18 @@ di superficie pubblica, quindi con analisi d'impatto. `PREFISSO_PROTOCOLLO_CACHE
 resta piu' stretto di entrambe di proposito: e' la guardia che difende la riga
 *per stream*, non la definizione di cio' che il parser legge.
 
-**La meta' statica non arriva ovunque.** Se un valore interpolato finisca in
-`.wav` lo decide il runtime, non il sorgente: `  ✓ {path}` di
-`score_visualizer.py` ha la stessa sagoma del blocco riassuntivo e oggi stampa
-`.png`. La guardia statica riconosce la sagoma, non l'estensione; a chiudere
-quella meta' e' il test di comportamento.
+**La meta' statica non arriva ovunque, e il confine non e' dove sembra.** La
+guardia riconosce come "forma di path" solo la *sagoma pura* — indentazione
+piu' interpolazione e nient'altro — perche' e' l'unica su cui un sorgente
+basti: se un valore finisca in `.wav` lo decide il runtime. `_RE_STEM_PATH` a
+valle e' invece molto piu' larga: le basta una riga indentata che contenga
+`__` e finisca in `.aif/.aiff/.wav/.flac`, e il resto della riga puo' essere
+qualunque cosa. Percio' `  ✓ {path}` di `score_visualizer.py` (oggi un `.png`)
+e la riga `  Path cercato: {path}` di `SampleNotFoundError` **cadono fuori
+dalla guardia statica** pur potendo entrare nel parser a runtime: e' la stessa
+collisione descritta sopra, e a chiuderla non c'e' un `ast` ma il test di
+comportamento — piu' l'abitudine, qui sotto, di guardare ogni riga indentata
+che finisce con un path.
 
 ## Implicazioni codice
 

--- a/docs/explanation/contratto-stdout.md
+++ b/docs/explanation/contratto-stdout.md
@@ -5,6 +5,9 @@ status: stable
 tags: [logging, stdout, protocollo, pge-ui, strategie]
 sources:
   - src/pge/shared/logger.py
+  - src/pge/cli.py
+  - src/pge/api.py
+  - src/pge/engine/generator.py
   - src/pge/strategies/strategy_registry.py
   - src/pge/strategies/variation_registry.py
   - src/pge/strategies/voice_pan_strategy.py
@@ -13,9 +16,11 @@ sources:
   - src/pge/rendering/csound_renderer.py
   - src/pge/rendering/supercollider_renderer.py
   - src/pge/rendering/stream_cache_manager.py
+  - src/pge/rendering/score_writer.py
+  - src/pge/rendering/score_visualizer.py
   - tests/shared/test_stdout_contract.py
-  - src/pge/cli.py
-last_synced_commit: 973cffd
+  - tests/test_api_stdout.py
+last_synced_commit: 17a0d4f
 ---
 
 # Il contratto di stdout — protocollo, diagnostica, interfaccia
@@ -34,9 +39,9 @@ motivo per cui la cosa e' rimasta com'era a lungo.
 Non e' disordine. **Stdout non e' un canale libero: e' un'interfaccia.**
 `render_pipeline.py` di PGE-ui legge le righe di `pge` una per una e ne ricava
 gli eventi NDJSON dell'editor — la barra di avanzamento, i pallini di stato dei
-singoli stem, l'indice dei file generati. Le righe che quel parser riconosce
-sono un contratto fra due repository, e nessuno dei due lo dichiara: sta in una
-manciata di regex da una parte e in una manciata di f-string dall'altra.
+singoli stem. Quelle righe sono un contratto fra due repository, e nessuno dei
+due lo dichiarava: stavano in una manciata di regex da una parte e in una
+manciata di f-string dall'altra.
 
 Da qui il rischio delle due direzioni opposte, che non e' simmetrico:
 
@@ -48,167 +53,237 @@ Da qui il rischio delle due direzioni opposte, che non e' simmetrico:
 
 ## Modello
 
-Tre categorie, per destinatario e non per contenuto:
+Tre categorie, per **destinatario** e non per contenuto:
 
 | Categoria | Chi la legge | Canale |
 |---|---|---|
-| **Protocollo** | il parser di PGE-ui | stdout, con quel formato esatto |
-| **Diagnostica** | uno sviluppatore che sta estendendo il motore | logger `pge.diagnostics` |
+| **Protocollo** | il parser di PGE-ui | stdout, con quella forma esatta |
+| **Diagnostica** | chi sta estendendo il motore | logger `pge.diagnostics` |
 | **Interfaccia CLI** | l'utente, a schermo | stdout, ma non e' protocollo |
 
-Il **protocollo** oggi sono le righe `[CACHE] <id>: DIRTY|clean` — da cui
-l'editor deriva `stream-start` e `stream-done` — e i path del blocco
-riassuntivo. Restano `print(..., flush=True)`: senza flush arriverebbero a
-rendering finito, quando non hanno piu' niente da annunciare.
+Il criterio fra le ultime due e' l'unico che richiede un giudizio, e si riduce
+a una domanda: **di chi parla la riga.** Del render di chi ha lanciato il
+comando — cosa sta producendo, quanto ci ha messo, dove sono i file, cosa non
+andava nel suo YAML — oppure della contabilita' interna del motore.
 
-**A emettere quella riga sono quattro moduli, non tre.** I tre renderer la
-stampano sul percorso diretto, uno stream alla volta; la pipeline in due stadi
-non passa di li' — `Generator.write_sco_files` delega a
-`StreamCacheManager.get_dirty_stream_dicts`, ed e' quel metodo a stampare la
-riga per tutti gli stream in blocco, prima che un renderer esista. E' una
-distinzione che conta perche' `stream_cache_manager.py` compare anche fra i
-moduli con `print()` non ancora classificati (sotto): la sua riga per stream e'
-gia' classificata, ed e' protocollo.
+### Chi parsa, e cosa: il censimento del lato PGE-ui
 
-Il prefisso `[CACHE]` da solo non identifica il protocollo. La regex a valle e'
-`^\[CACHE\]\s+(\S+):\s+(.+)$`: vuole un token *senza spazi* seguito dai due
-punti. Cadono fuori `[CACHE] <n>/<m> stream da ricompilare` (stesso metodo) e
-`[CACHE] Stream da scrivere: [...]` (`Generator`), che infatti nessuno parsa.
+`render_pipeline.py` riconosce **due** forme, e nient'altro. Ogni altra riga
+diventa un evento `log`, che l'editor stampa nel suo terminale senza leggerla:
 
-**Ma la forma non basta a identificare il protocollo, e va detto qui perche' e'
-il posto dove si va a cercarlo.** Un token *letterale* soddisfa quella regex
-quanto un id interpolato, e due righe di `cli.py` lo fanno:
-`[CACHE] Manifest: <path>` a ogni render con `--cache`, e
-`[CACHE] GC: rimossi N stream orfani: [...]` quando la GC rimuove qualcosa.
-L'editor le matcha entrambe. A scartarle non e' la loro forma ma l'insieme
-degli id che la richiesta dichiara — e quel filtro e' **inerte** quando la
-richiesta non li dichiara, dove resta il comportamento storico. Il commento di
-`render_pipeline.py` lo dice in prima persona: *«non tutte le righe `[CACHE]`
-sono stream, e la forma non le distingue»*.
+| Forma | Regex a valle | Evento |
+|---|---|---|
+| `[CACHE] <token-senza-spazi>: <resto>` | `_RE_CACHE_LINE` | `stream-start`, `stream-done` |
+| `    <path>__<id>.<aif\|aiff\|wav\|flac>` | `_RE_STEM_PATH` | `stream-done` dell'ultimo stream DIRTY |
 
-Da cui la regola che conta, e che e' piu' stretta di quella che si dedurrebbe
-dalla tabella: **ogni riga nella forma `[CACHE] <token-senza-spazi>: <resto>`
-finisce dentro il parser di PGE-ui, qualunque cosa dica.** Aggiungerne una
-nuova non e' diagnostica ne' interfaccia CLI: e' un'aggiunta al protocollo, e
-va trattata come tale.
+Verificato eseguendo, non leggendo: un render vero passato dentro
+`parse_render_line` produce eventi **solo** su quelle due. L'esito del render
+(`ok`, `returncode`) e la lista dei file generati non passano da stdout — il
+bridge li ricava dal codice di uscita del processo e da una `glob` su disco.
 
-La guardia si regola su un criterio piu' stretto ancora — pretende un `{}`
-interpolato in prima posizione (`[CACHE] {}: `) — e non e' una svista: il suo
-mestiere e' difendere la riga *per stream*, non definire cosa il parser legge.
-Cerca cioe' meno di quel che il parser trova, che e' la direzione sicura per
-una guardia che deve dire «questa riga e' sparita».
+Ci sono poi tre righe che l'editor riconosce **solo per colorarle**
+(`classifyLogLine` in `app.jsx`: `[ERROR]|Errore|errno|traceback`,
+`[CACHE]|cached`, `Generazione completata|→ output/`). E' un accoppiamento piu'
+debole — cambiare quelle righe cambia un colore, non un evento — ma esiste, e
+va saputo prima di riscriverle.
 
-La **diagnostica** oggi sono le registrazioni dinamiche di strategy
-(`register_density_strategy`, `register_variation_strategy`,
-`register_voice_pan_strategy`). Passano da `log_strategy_registration`, che
-scrive sul logger `pge.diagnostics`. Quel logger e' fatto di due astensioni:
+### Le due righe di protocollo
 
-1. **nessun handler proprio oltre a un `NullHandler`.** Una libreria non
-   configura il logging del suo ospite. Qui l'astensione ha anche un effetto
-   concreto: `get_engine_logger()` si auto-configura, e configurarsi vuol dire
-   `os.makedirs('./logs')` — una cartella materializzata sul disco di chi
-   passava di li' solo per registrare una strategy. Il `NullHandler` serve al
-   resto: senza handler, `logging` manda i record da WARNING in su a
-   `lastResort`, che scrive su stderr;
-2. **livello DEBUG.** Sotto il livello di default del root (WARNING) il record
-   non viene nemmeno costruito, quindi la diagnostica muta non costa niente su
-   un percorso caldo. Chi la vuole fa `logging.basicConfig(level=logging.DEBUG)`,
-   e la console di `logging` e' **stderr**: nemmeno accendendola si rientra nel
-   canale che PGE-ui parsa.
+La prima e' `[CACHE] <id>: DIRTY|clean`, da cui l'editor deriva l'avanzamento
+per stream. La emettono i tre renderer, uno stream alla volta, e
+`StreamCacheManager.get_dirty_stream_dicts` per tutti in blocco. Restano
+`print(..., flush=True)`: senza flush arriverebbero a rendering finito, quando
+non hanno piu' niente da annunciare.
 
-**Ma i punti di registrazione dinamica sono sette, non tre, e non stanno tutti
-in `strategies/`.** La #187 ne ha convertiti tre perche' erano i tre che
-stampavano; gli altri quattro (onset, pointer, pitch, window) erano gia' muti.
-Il settimo, `register_window_strategy`, vive in
-`controllers/window_selection_strategy.py`, dove vive il registry delle
-finestre: una guardia scoped sulla cartella `strategies/` ne copre sei e tace
-sul settimo, che e' la porta da cui la `print()` puo' rientrare senza che nulla
-suoni. Anche quella lista e' quindi dichiarata *e* derivata dai sorgenti, e il
-criterio del test e' la **funzione** `register_*_strategy`, non il modulo che
-la contiene.
+Quel quarto emettitore e' pero' **irraggiungibile**: il suo unico chiamante e'
+`Generator.generate_score_files_per_stream`, che a sua volta non ne ha
+(`tests/test_api_stdout.py` li elenca entrambi fra gli irraggiungibili). Resta
+sorvegliato lo stesso, perche' la forma e' quella del protocollo: il giorno
+che qualcuno ricollega quel percorso, la riga arriva al parser senza che
+nessuno debba deciderlo di nuovo. *(Questo doc chiamava quel metodo
+`Generator.write_sco_files`, che non esiste e non e' mai esistito.)*
+
+La seconda e' il **blocco riassuntivo** di `cli.py`, e fin qui non era
+nominata: sotto «Generazione completata! N file generati:» ogni path esce
+indentato di quattro spazi, e da li' `parse_render_line` ricava lo
+`stream-done` dell'**ultimo** stream DIRTY del giro — gli altri li chiude la
+riga `[CACHE]` successiva, l'ultimo non ha nessuna riga dopo di se'. Fino alla
+#178 non aveva nessuna guardia: togliendole l'indentazione la suite di PGE
+resta interamente verde e l'ultimo stem prende il pallino giallo dopo un render
+che ha fatto esattamente cio' che il pallino chiedeva.
+
+### La forma non dice l'intenzione
+
+**Ogni riga nella forma `[CACHE] <token-senza-spazi>: <resto>` finisce dentro
+il parser di PGE-ui, qualunque cosa dica.** Un token letterale soddisfa quella
+regex quanto un id interpolato, e due righe di `cli.py` lo fanno:
+`[CACHE] Manifest: <path>` a ogni render con `--cache`, e `[CACHE] GC: rimossi
+N stream orfani: [...]` quando la GC rimuove qualcosa.
+
+A scartarle non e' la loro forma ma l'insieme degli id che la richiesta
+dichiara, e quel filtro e' **inerte** quando la richiesta non li dichiara.
+Misurato su un render vero: col filtro inerte l'editor apre uno stream di nome
+`Manifest` e uno di nome `GC`. Sono percio' classificate protocollo — non
+perche' l'editor ne ricavi qualcosa di utile, ma perche' occupano quello
+spazio di nomi e spostarle e' un cambio di superficie pubblica.
+
+Lo stesso vale per la forma del path, con una collisione in piu' che la #178 ha
+misurato: **qualunque riga indentata che finisca per `__<qualcosa>.<ext>` e'
+candidata**. Un sample chiamato `voce__streamA.wav` citato dalla riga
+`  Path cercato:` di un `SampleNotFoundError` chiude in anticipo lo stream
+`streamA` — pallino verde su uno stem mai scritto. Stretta, ma reale: le righe
+umane e il protocollo condividono uno spazio di forme.
+
+### Stderr non e' un riparo
+
+Questo doc e `logger.py` scrivevano che la diagnostica e' al sicuro perche' la
+console di `logging` e' stderr, «nemmeno accendendola si rientra nel canale che
+PGE-ui parsa». **E' falso.** Il bridge lancia il motore con
+`stderr=subprocess.STDOUT` (`RenderState.start`): i due flussi arrivano allo
+stesso `readline`, e ogni riga passa per `parse_render_line`.
+
+Misurato. Con l'host che accende la diagnostica come chiunque la accenderebbe —
+`logging.basicConfig(level=logging.DEBUG, format="%(message)s")` — un record
+`[CACHE] %s: registrata` ha prodotto `stream-start` e `stream-done` per uno
+stream di nome `gaussian`, che non esiste. Nel formato di default a salvarlo e'
+solo il prefisso `DEBUG:pge.diagnostics:` che il formatter antepone: una scelta
+dell'host, non una garanzia del motore.
+
+Quindi la regola vera non e' «il logger e' un altro canale». E': **nessuno, su
+nessun canale, scrive righe che hanno la forma del protocollo.** Il file
+descriptor non separa niente; separa la forma.
+
+### La classificazione
+
+Sessantaquattro `print()` in `src/pge/`. La tabella completa vive in
+`CLASSIFICAZIONE` (`tests/shared/test_stdout_contract.py`), dove e' eseguibile;
+qui il riassunto per modulo:
+
+| Modulo | Protocollo | Diagnostica | Interfaccia CLI |
+|---|---|---|---|
+| `cli.py` | `    <path>`, `[CACHE] Manifest:`, `[CACHE] GC:` | — | 36 (usage, errori dei flag, avanzamento, riepiloghi, path degli artefatti) |
+| `engine/generator.py` | — | `  → Stream '<id>': <repr>`, `[CACHE] Stream da scrivere:` | `[SEED]`, `Creazione di N stream`, `⚡ SOLO MODE`, `🔇 N stream muted`, `⚠️ impossibile valutare` |
+| `rendering/*_renderer.py` (3) | `[CACHE] <id>: <status>` | — | — |
+| `rendering/stream_cache_manager.py` | `[CACHE] <id>: <status>` | — | `[CACHE] N/M stream da ricompilare` |
+| `rendering/score_writer.py` | — | — | 4 (path del `.sco` e riepilogo) |
+| `rendering/score_visualizer.py` | — | — | 7 (avanzamento PDF/PNG, waveform illeggibile) |
+| `shared/logger.py` | — | — | `📝 Clip log file:`, `CLIP:` (su stderr) |
+
+La **diagnostica e' quasi vuota**, ed e' l'esito piu' istruttivo del
+censimento. Dopo che la #187 ha portato al logger le registrazioni di strategy,
+restano due sole righe che parlano della contabilita' interna: il `repr` per
+stream di `_create_streams` e l'elenco `[CACHE] Stream da scrivere:` — che sta
+per giunta nel ramo irraggiungibile. Tutto il resto dello stdout del motore e'
+**interfaccia**: parla del render di chi ha lanciato il comando. Non c'era una
+riserva di rumore da spostare al logger; c'era un canale mal dichiarato.
+
+Due voci meritano una nota, perche' sono quelle su cui la classificazione e'
+una scelta e non una lettura:
+
+- `  → Stream '<id>': <repr>` — l'ho classificata diagnostica perche' il `repr`
+  espone stato interno (`grains=lazy`), ed e' una riga per stream: su
+  quaranta stream e' un muro. Ma e' anche l'unica conferma visibile che uno
+  stream e' stato costruito, quindi spostarla **cambia cio' che l'utente
+  vede**: e' una decisione di prodotto, non un refactoring, e va presa con
+  l'utente nella issue di esecuzione.
+- `📝 Clip log file: <path>` — questo doc diceva che passa «a ogni render».
+  Falso: `get_clip_logger()` e' lazy, e la riga esce al **primo clip**, una
+  volta per configurazione. Non e' traffico di ogni rendering; e' l'annuncio
+  di un artefatto che esiste solo quando c'e' qualcosa da scriverci dentro.
+
+### La decisione: implicito, ma dichiarato
+
+Il protocollo **resta implicito** — righe di testo riconosciute da una regex a
+valle — e smette di essere **implicitamente** tale.
+
+Un canale esplicito (NDJSON su un fd dedicato, un `--events`) toglierebbe alla
+radice le collisioni di forma e permetterebbe eventi che oggi non esistono:
+`stream-progress` e' gia' gestito in `app.jsx` e nessuno lo emette. Ma e' un
+impegno cross-repo — due protocolli da mantenere finche' PGE-ui non migra — e
+soprattutto non risolve quello che sembra risolvere: le righe umane restano su
+stdout e restano accidentalmente parsabili, perche' il motore resta una CLI che
+parla a una persona. Il costo e' certo, il guadagno parziale.
+
+Cio' che l'implicitezza costava era invece rimediabile a costo zero: le righe
+di protocollo sono dichiarate qui e sorvegliate da
+`tests/shared/test_stdout_contract.py`, che oggi copre entrambe (la seconda non
+aveva nulla) e pretende che ogni `print()` di `src/pge/` abbia una categoria.
+
+**Quando diventare espliciti.** Non «quando ci sara' tempo», che non e' un
+criterio. Tre condizioni, ognuna sufficiente:
+
+1. **un secondo consumatore** — oggi PGE-ui e' l'unico (verificato: PGE-ls,
+   gl-ls e granulation-studies non leggono lo stdout del motore). Due parser
+   sulla stessa prosa e la forma smette di bastare;
+2. **un evento che la forma-riga non sa portare** — avanzamento sub-stream,
+   dati strutturati per grano: qualsiasi cosa richieda di annidare;
+3. **una terza collisione** — le prime due (`Manifest`/`GC`, il path del
+   sample nell'errore) sono state assorbite dai filtri a valle. La terza dice
+   che i filtri stanno diventando il protocollo.
 
 ## Trade-off
 
-**La conferma di registrazione diventa muta.** Prima, registrare una strategy
-stampava una riga con la spunta verde; ora non stampa niente finche' l'host non
-accende il logging. E' il costo accettato: la registrazione dinamica e'
-un'operazione da sviluppatore che in una pipeline di rendering normale non
-compare mai, e chi la sta facendo e' esattamente la persona in grado di alzare
-un livello di log. Il messaggio non e' andato perso — ha cambiato canale.
+**La conferma di registrazione delle strategy e' muta.** Prima stampava una
+riga con la spunta verde; ora non stampa finche' l'host non accende il logging.
+E' il costo accettato dalla #187: la registrazione dinamica e' un'operazione da
+sviluppatore che in una pipeline di rendering normale non compare mai, e chi la
+sta facendo e' esattamente la persona in grado di alzare un livello di log.
 
 **Non c'e' una `configure_diagnostic_logger()`.** Sarebbe stata simmetrica alle
 due che esistono (clip ed engine), ma quelle configurano dei *file di
 rendering*, cioe' un prodotto del programma; questa avrebbe configurato il
 logging di chi importa `pge`, che non e' affare di `pge`.
 
-**La classificazione e' un test, non una prosa.** `tests/shared/test_stdout_contract.py`
-legge i sorgenti con `ast` e chiede quattro cose: che la riga
-`[CACHE] <id>: ...` sia ancora un `print()` flushato in tutti e quattro i
-moduli che la emettono; che quei quattro siano **tutti** quelli che la
-emettono; che in `src/pge/strategies/` non ci sia nessun `print()`; e che
-nessun `register_*_strategy` stampi, ovunque viva. Il primo e' l'unico presidio
-che csound e supercollider abbiano su quella riga (numpy e il cache manager
-hanno anche un test di comportamento); il terzo e il quarto sono cio' che
-impedisce alla porta di riaprirsi in silenzio, e sono due perche' uno solo non
-bastava: il terzo guarda una cartella, e il settimo entry point non ci sta
-dentro.
+**La classificazione e' un test, non una prosa.** `test_stdout_contract.py`
+legge i sorgenti con `ast` e chiede sei cose: che la riga `[CACHE] <id>: ...`
+sia ancora un `print()` flushato nei quattro moduli che la emettono; che quei
+quattro siano **tutti** quelli che la emettono; che il blocco riassuntivo esca
+ancora indentato e col suffisso `__<id>` (e questo lo misura sull'output vero,
+facendo scrivere alla CLI il suo riepilogo — un `print()` letto con `ast` direbbe
+che la riga esiste, solo i byte dicono che esce indentata); che ogni `print()`
+di `src/pge/` abbia una categoria e ogni categoria una `print()`; che nessuna
+riga non-protocollo abbia forma di protocollo; e che nessun **messaggio di
+log** ce l'abbia, perche' stderr non e' un riparo.
 
-Il secondo e il quarto coprono il buco che una lista scritta a mano ha per
-costruzione: un
-backend nuovo che dichiara lo stato della cache emette la stessa riga e non
-entra nella lista da solo, e la guardia sarebbe rimasta verde sopra un
-emettitore che nessuno sorveglia — sul canale dove csound e supercollider non
-hanno altro; e un registry che sta in un'altra cartella non entra nella guardia
-della diagnostica, che infatti ne sorvegliava sei su sette. Entrambe le liste
-sono quindi confrontate con cio' che i sorgenti fanno, e la checklist di
-[[add-renderer]] porta lo stesso passo.
+**La tabella dice dove una riga sta, non dove dovrebbe andare.** Spostare
+un'INTERFACCIA al logger resta una scelta di prodotto: cambia cio' che l'utente
+vede. Quel che la tabella impedisce e' di spostarne una senza accorgersi che
+era protocollo.
 
-**La guardia riconosce la forma, non il prefisso.** Le chiamate sono
-ricomposte in un *template* — ogni interpolazione di una f-string diventa `{}`,
-senza guardarci dentro — e cio' che si pretende e' `[CACHE] {}: `. Cercare la
-sottostringa `[CACHE]` sarebbe bastato per i renderer e non per il cache
-manager, dove sopravvive comunque un `[CACHE] <n>/<m> stream da ricompilare`
-che nessuno parsa: la guardia sarebbe rimasta verde dopo aver spostato al
-logger l'unica riga che l'editor legge davvero. Due test misurano proprio il
-discrimine, cosi' che a indebolirlo qualcosa suoni.
+**Due regex sono trascritte da PGE-ui**, che da qui non e' importabile.
+`FORMA_PROTOCOLLO_CACHE` e `FORMA_PROTOCOLLO_PATH` sono copie, e come ogni copia
+possono invecchiare: se cambiano di la', vanno aggiornate qui — ed e' un cambio
+di superficie pubblica, quindi con analisi d'impatto. `PREFISSO_PROTOCOLLO_CACHE`
+resta piu' stretto di entrambe di proposito: e' la guardia che difende la riga
+*per stream*, non la definizione di cio' che il parser legge.
+
+**La meta' statica non arriva ovunque.** Se un valore interpolato finisca in
+`.wav` lo decide il runtime, non il sorgente: `  ✓ {path}` di
+`score_visualizer.py` ha la stessa sagoma del blocco riassuntivo e oggi stampa
+`.png`. La guardia statica riconosce la sagoma, non l'estensione; a chiudere
+quella meta' e' il test di comportamento.
 
 ## Implicazioni codice
 
 - **Aggiungi una riga diagnostica** → `get_diagnostic_logger().debug(...)`, con
   formattazione `%s` pigra. Mai `print()`.
+- **Aggiungi una riga qualunque** → va classificata in `CLASSIFICAZIONE`
+  (`tests/shared/test_stdout_contract.py`), o la suite e' rossa. E' il posto
+  dove la #178 ha messo la risposta a «questa riga chi la legge».
 - **Aggiungi un renderer** → se dichiara lo stato della cache, la riga
   `[CACHE] <id>: <status>` va su stdout con `flush=True`, e il modulo va
-  aggiunto a `MODULI_CON_PROTOCOLLO_CACHE` nella guardia. Vedi [[add-renderer]].
+  aggiunto a `MODULI_CON_PROTOCOLLO_CACHE`. Vedi [[add-renderer]].
+- **Scrivi una riga `[CACHE] <token>: ...`** → e' protocollo per il solo fatto
+  della forma, anche se il token e' una parola e non un id. Vale su stdout e
+  **anche sul logger**: non c'e' un canale in cui quella forma sia libera.
+- **Scrivi una riga indentata che finisce con un path** → controlla che non
+  possa finire per `__<qualcosa>.<aif|aiff|wav|flac>`. Quella forma chiude lo
+  stream in corso nell'editor.
 - **Cambi il formato di una riga di protocollo** → e' un cambio di superficie
   pubblica: serve l'analisi d'impatto su PGE-ui e PGE-ls prima, non dopo.
-- **Aggiungi una riga `[CACHE] <token>: ...`** → e' protocollo per il solo
-  fatto della forma, anche se il token e' una parola e non un id. Prima di
-  scriverla, l'analisi d'impatto su PGE-ui.
-- **Il resto dei `print()`** (`engine/generator.py`,
-  `rendering/score_visualizer.py`, `rendering/stream_cache_manager.py`,
-  `rendering/score_writer.py`, `shared/logger.py`, `cli.py`) non e' ancora
-  classificato: sono gli scaglioni successivi. Attenzione: quei moduli non sono
-  omogenei. `stream_cache_manager.py` e `generator.py` contengono *anche* righe
-  gia' classificate — la riga per stream del primo e' protocollo e ha la sua
-  guardia; quel che resta da classificare li' e' il riepilogo
-  `[CACHE] <n>/<m> stream da ricompilare` e `[CACHE] Stream da scrivere: [...]`,
-  che nessun parser legge. `cli.py` concentra la maggioranza del resto ed e' in
-  larga parte *interfaccia CLI*, cioe' la terza categoria — quella che resta su
-  stdout pur non essendo protocollo. **Con due eccezioni gia' note**, ed e' bene
-  arrivarci sapendolo: `[CACHE] Manifest: <path>` e `[CACHE] GC: ...` hanno la
-  forma che il parser matcha, quindi non sono libere di andarsene al logger
-  come fosse diagnostica — e nessuna delle due esce con `flush=True`, il che le
-  rende un caso da guardare, non da spostare a occhio. E' anche la categoria
-  dove la scelta non e' meccanica: la riga per stream dei conteggi di grani
-  (#250) la legge un compositore a schermo, non un parser, ma sta sullo stesso
-  canale che un parser attraversa.
-- **Il meno atteso della lista e' `shared/logger.py`**, che e' poi il modulo
-  dove abita il logger diagnostico: `configure_clip_logger` stampa una riga
-  `Clip log file: <path>` su **stdout**, e la CLI ci passa a ogni render
-  (`file_enabled=True`). Non e' quindi una riga da sviluppatore come le tre che
-  la #187 ha spostato: e' traffico di *ogni* rendering, sul canale che il
-  parser attraversa. L'altra `print()` del modulo scrive gia' su `sys.stderr`
-  e non pone il problema.
+- **Vuoi zittire la libreria** → `contextlib.redirect_stdout` non basta: serve
+  anche `redirect_stderr`, oppure `configure_clip_logger(console_enabled=False)`.
+  Il censimento in testa a `api.py` elenca riga per riga cosa esce e da dove.
 
 ## Vedi anche
 

--- a/src/pge/api.py
+++ b/src/pge/api.py
@@ -53,16 +53,32 @@
 #
 # --- fine censimento ---
 #
-# Perche' restano: fanno parte del contratto stdout della CLI, e almeno una
-# e' interfaccia vera. `[CACHE] <id>: DIRTY|clean` la parsa PGE-ui
-# (render_pipeline.py, _RE_CACHE_LINE) per costruirne gli eventi NDJSON
-# `stream-start`/`stream-done`: spostarla al logger rompe l'avanzamento per
-# stream nell'editor dell'altro repo. Le altre nessuno le parsa, per quanto
-# se ne sa -- ma "per quanto se ne sa" e' esattamente cio' che la issue #178
-# deve accertare (protocollo / diagnostica / interfaccia CLI) prima che le
-# #187/#188 le portino al logger. Quando succedera', il censimento qui sopra
-# va aggiornato: il test lo verifica in entrambe le direzioni (nessuna riga
-# fuori elenco, nessuna voce in elenco che nessuno emette piu').
+# Perche' restano: fanno parte del contratto stdout della CLI, e la #178 ha
+# accertato quale sia il ruolo di ognuna (protocollo / diagnostica /
+# interfaccia CLI). La classificazione completa sta in
+# docs/explanation/contratto-stdout.md ed e' eseguibile in
+# tests/shared/test_stdout_contract.py; qui basta sapere cosa cambia per chi
+# incorpora:
+#
+# - `[CACHE] <id>: DIRTY|clean` e' **protocollo**: PGE-ui la parsa
+#   (render_pipeline.py, _RE_CACHE_LINE) per costruirne gli eventi NDJSON
+#   `stream-start`/`stream-done`. Spostarla al logger rompe l'avanzamento per
+#   stream nell'editor dell'altro repo;
+# - `  → Stream '<id>': <repr>` e' **diagnostica** -- l'unica di questo
+#   elenco;
+# - tutte le altre sono **interfaccia CLI**: nessuno le parsa, ma le legge a
+#   schermo chi ha lanciato il render, quindi spostarle e' una scelta di
+#   prodotto e non un refactoring.
+#
+# Attenzione a una cosa che non si vede da qui: PGE-ui unisce stderr a stdout
+# (`stderr=subprocess.STDOUT`), quindi anche le righe di stderr elencate piu'
+# sotto attraversano quel parser. A tenerle fuori dagli eventi e' la loro
+# forma, non il canale.
+#
+# Quando le issue di esecuzione porteranno qualcuna di queste righe al logger,
+# il censimento qui sopra va aggiornato: il test lo verifica in entrambe le
+# direzioni (nessuna riga fuori elenco, nessuna voce in elenco che nessuno
+# emette piu').
 #
 # --- e stderr, che il censimento qui sopra non copre ---
 #

--- a/src/pge/shared/logger.py
+++ b/src/pge/shared/logger.py
@@ -228,8 +228,26 @@ def get_engine_log_path() -> str | None:
 #    chiama `setLevel`, quindi il livello effettivo lo eredita dal root e a
 #    deciderlo e' l'host. Sotto il default del root (WARNING) il record non
 #    viene nemmeno costruito, quindi la diagnostica muta non costa. Chi la
-#    vuole fa `logging.basicConfig(level=logging.DEBUG)`, e la console di
-#    `logging` e' stderr: nemmeno accendendola si rientra in stdout.
+#    vuole fa `logging.basicConfig(level=logging.DEBUG)`.
+#
+# **Quello che stderr NON e' e' un riparo**, e qui c'era scritto il
+# contrario: «la console di logging e' stderr, nemmeno accendendola si
+# rientra in stdout». Vero sul file descriptor, falso sul canale che conta.
+# Il bridge di PGE-ui lancia il motore con `stderr=subprocess.STDOUT`
+# (`RenderState.start` in `render_pipeline.py`): i due flussi arrivano allo
+# stesso `readline`, e ogni riga passa per `parse_render_line`. Misurato
+# nella #178: con `logging.basicConfig(level=DEBUG, format="%(message)s")` —
+# la configurazione piu' ordinaria che ci sia — un record diagnostico che
+# cominci per `[CACHE] <token>: ` ha prodotto nell'editor uno `stream-start`
+# e uno `stream-done` per uno stream che non esiste. A separarlo dal
+# protocollo nel formato di default e' soltanto il prefisso
+# `DEBUG:pge.diagnostics:` che il formatter antepone, cioe' una scelta
+# dell'host.
+#
+# Quindi la regola non e' «il logger e' un altro canale», e' **nessuno, su
+# nessun canale, scrive righe con la forma del protocollo**. La tiene ferma
+# `test_nessun_messaggio_di_log_ha_la_forma_del_protocollo` in
+# `tests/shared/test_stdout_contract.py`.
 #
 #    Il NOTSET e' la meta' portante, non un dettaglio omesso. Un
 #    `logger.setLevel(logging.DEBUG)` qui non renderebbe la diagnostica

--- a/src/pge/shared/logger.py
+++ b/src/pge/shared/logger.py
@@ -230,6 +230,15 @@ def get_engine_log_path() -> str | None:
 #    viene nemmeno costruito, quindi la diagnostica muta non costa. Chi la
 #    vuole fa `logging.basicConfig(level=logging.DEBUG)`.
 #
+#    Il NOTSET e' la meta' portante, non un dettaglio omesso. Un
+#    `logger.setLevel(logging.DEBUG)` qui non renderebbe la diagnostica
+#    "accendibile": la renderebbe *accesa*. `Logger.callHandlers` confronta il
+#    record col livello dell'**handler**, non ricontrolla quello del logger, e
+#    un `logging.basicConfig()` senza argomenti lascia il suo StreamHandler a
+#    NOTSET: ogni host che lo chiama si troverebbe la diagnostica su stderr
+#    senza averla chiesta. Il livello del logger e' dell'host, e va lasciato
+#    dov'e'. Lo fissa `test_diagnostic_logger_non_impone_un_livello`.
+#
 # **Quello che stderr NON e' e' un riparo**, e qui c'era scritto il
 # contrario: «la console di logging e' stderr, nemmeno accendendola si
 # rientra in stdout». Vero sul file descriptor, falso sul canale che conta.
@@ -245,18 +254,12 @@ def get_engine_log_path() -> str | None:
 # dell'host.
 #
 # Quindi la regola non e' «il logger e' un altro canale», e' **nessuno, su
-# nessun canale, scrive righe con la forma del protocollo**. La tiene ferma
-# `test_nessun_messaggio_di_log_ha_la_forma_del_protocollo` in
+# nessun canale, scrive righe con la forma del protocollo**. Le forme sono
+# due — `[CACHE] <token>: <resto>` e una riga di sola indentazione piu' un
+# path che finisca in `.aif/.wav/.flac` — e la seconda e' quella che il
+# logger scrive con piu' naturalezza (`log.debug("    %s", path)`). Le tiene
+# ferme entrambe `test_nessun_messaggio_di_log_ha_la_forma_del_protocollo` in
 # `tests/shared/test_stdout_contract.py`.
-#
-#    Il NOTSET e' la meta' portante, non un dettaglio omesso. Un
-#    `logger.setLevel(logging.DEBUG)` qui non renderebbe la diagnostica
-#    "accendibile": la renderebbe *accesa*. `Logger.callHandlers` confronta il
-#    record col livello dell'**handler**, non ricontrolla quello del logger, e
-#    un `logging.basicConfig()` senza argomenti lascia il suo StreamHandler a
-#    NOTSET: ogni host che lo chiama si troverebbe la diagnostica su stderr
-#    senza averla chiesta. Il livello del logger e' dell'host, e va lasciato
-#    dov'e'. Lo fissa `test_diagnostic_logger_non_impone_un_livello`.
 DIAGNOSTIC_LOGGER_NAME = 'pge.diagnostics'
 
 _diagnostic_logger: logging.Logger | None = None

--- a/tests/rendering/test_stream_cache_manager.py
+++ b/tests/rendering/test_stream_cache_manager.py
@@ -581,12 +581,18 @@ class TestDirtyStreamFiltering:
     ):
         """`[CACHE] <id>: DIRTY|clean` su stdout, uno per stream (issue #187).
 
-        Non e' una riga di servizio: e' quella da cui `parse_render_line` di
-        PGE-ui ricava `stream-start` e `stream-done`. Qui esce prima che un
-        renderer esista — la pipeline in due stadi passa da
-        `Generator.write_sco_files`, che delega a questo metodo. E' anche
-        l'emettitore piu' esposto: gli altri `print()` di questo modulo la
-        #178 non li ha ancora classificati, quindi qualcuno ci ripassera'.
+        Non e' una riga di servizio: ha la forma da cui `parse_render_line`
+        di PGE-ui ricava `stream-start` e `stream-done`, e qui esce prima che
+        un renderer esista.
+
+        Con un'avvertenza che la #178 ha accertato e che conviene tenere
+        insieme all'asserzione: l'unico chiamante di questo metodo in
+        `src/pge/` e' `Generator.generate_score_files_per_stream`, che a sua
+        volta non ha chiamanti. Nessun render passa di qui, e infatti
+        `tests/test_api_stdout.py` lo elenca fra gli irraggiungibili. La riga
+        resta protocollo *per forma* — il giorno che qualcuno ricollega quel
+        percorso, arriva al parser dell'editor senza doverlo decidere di
+        nuovo — e questa asserzione e' cio' che la tiene tale.
         Senza questa asserzione una conversione al logger non farebbe fallire
         niente, e la barra di avanzamento dell'editor resterebbe ferma a zero
         per tutto il rendering. Vedi `docs/explanation/contratto-stdout.md` e

--- a/tests/shared/test_stdout_contract.py
+++ b/tests/shared/test_stdout_contract.py
@@ -427,6 +427,17 @@ def _ha_forma_di_path(forma):
             and forma.replace('{}', '').strip() == '')
 
 
+def _ha_forma_di_protocollo(forma):
+    """La riga entrerebbe in una delle due forme che PGE-ui riconosce.
+
+    Le forme sono due, e questa e' l'unica funzione che lo dice: chi chiede
+    "questa riga finisce nel parser dell'editor" non deve ricordarsi di
+    chiederlo due volte. Chiederlo per la sola `[CACHE]` e' il modo in cui la
+    meta' del blocco riassuntivo e' rimasta scoperta la prima volta.
+    """
+    return _ha_forma_cache(forma) or _ha_forma_di_path(forma)
+
+
 def _stem_paths_su_stdout(testo):
     """Le righe di `testo` che PGE-ui leggerebbe come path di uno stem."""
     return [FORMA_PROTOCOLLO_PATH.match(r).group(1)
@@ -469,10 +480,19 @@ def test_lo_stream_done_si_aggancia_al_suffisso_dell_id(mocks, capsys):
     `.`/`-` sostituito, il basename accorciato — lascia il confronto senza
     aggancio, e lo stream in volo non si chiude mai. E' lo stesso difetto che
     la `\\w` nella regex a monte aveva gia' prodotto una volta.
+
+    Il caso e' quello che il test qui sopra non copre, ed e' anche l'unico su
+    cui il confronto per suffisso si distingue da uno per gruppo catturato:
+    un **basename che contiene gia' `__`**. Li' non c'e' una posizione del
+    separatore da indovinare — `_RE_STEM_PATH` cattura tutto fino
+    all'estensione e chi legge confronta la coda — e una `print()` che
+    provasse a "ripulire" il path lo romperebbe senza che nient'altro se ne
+    accorga. Senza questo caso l'asserzione era piu' debole di quella del test
+    precedente sugli stessi byte: non poteva fallire da sola.
     """
     api_mod = mocks['main'].api
     result = api_mod.RenderResult(
-        audio_paths=['/out/PGE_test__stream-B.2.wav'],
+        audio_paths=['/out/PGE__test__stream-B.2.wav'],
         elapsed_seconds=0.0, renderer_type='numpy', per_stream=True)
     argv = ['main.py', 'test.yml', 'out.wav', '--per-stream',
             '--renderer', 'numpy', '--format', 'wav']
@@ -482,7 +502,12 @@ def test_lo_stream_done_si_aggancia_al_suffisso_dell_id(mocks, capsys):
 
     trovati = _stem_paths_su_stdout(capsys.readouterr().out)
 
-    assert any(p.endswith('__stream-B.2') for p in trovati), (
+    assert trovati == ['/out/PGE__test__stream-B.2'], (
+        "il path dello stem non esce piu' intero: PGE-ui confronta la coda "
+        "`__<id>` su quel che la regex cattura, e un basename che contiene "
+        "gia' `__` non gli da' nessun separatore da indovinare."
+    )
+    assert trovati[0].endswith('__stream-B.2'), (
         "il path dello stem non finisce piu' per `__<id>`: PGE-ui confronta "
         "proprio quel suffisso per chiudere lo stream in corso."
     )
@@ -724,16 +749,23 @@ def test_solo_le_righe_di_protocollo_hanno_forma_di_protocollo():
     E' la meta' che rende la tabella qualcosa di piu' di un elenco. Le due
     forme che `render_pipeline.py` riconosce sono uno spazio di nomi
     condiviso: chiunque scriva `[CACHE] <token>: ...` ci finisce dentro,
-    qualunque cosa intendesse dire. Classificare una riga come interfaccia
+    qualunque cosa intendesse dire — e lo stesso vale per una riga fatta di
+    sola indentazione piu' un path. Classificare una riga come interfaccia
     non la tiene fuori dal parser — solo la sua forma lo fa.
+
+    Le forme da controllare sono percio' **due**, quante ne legge il parser.
+    Questo test ne guardava una: una `print(f"    {qualcosa}")` nuova, marcata
+    interfaccia, sarebbe passata — ed e' esattamente la riga del blocco
+    riassuntivo, cioe' l'altra meta' del protocollo.
     """
     for (modulo, forma), categoria in _classificazione_ordinata():
         if categoria == PROTOCOLLO or forma is None:
             continue
-        assert not _ha_forma_cache(forma), (
+        assert not _ha_forma_di_protocollo(forma), (
             f"{modulo}: `{forma}` e' classificata {categoria} ma ha la forma "
-            "che PGE-ui parsa come stream. O e' protocollo, o va riscritta.\n"
-            "Il prefisso `[CACHE] <token>: ` finisce nel parser dell'editor "
+            "che PGE-ui parsa. O e' protocollo, o va riscritta.\n"
+            "Le due forme — `[CACHE] <token>: ...` e una riga di sola "
+            "indentazione piu' un path — finiscono nel parser dell'editor "
             "qualunque cosa la riga intenda dire: vedi issue #178."
         )
 
@@ -751,8 +783,7 @@ def test_le_righe_di_protocollo_sono_quelle_che_il_parser_legge():
         if categoria != PROTOCOLLO:
             continue
         assert forma is not None, f"{modulo}: protocollo senza forma leggibile"
-        parsata = _ha_forma_cache(forma) or _ha_forma_di_path(forma)
-        assert parsata, (
+        assert _ha_forma_di_protocollo(forma), (
             f"{modulo}: `{forma}` e' marcata protocollo ma non ha nessuna "
             "delle due forme che PGE-ui parsa. Se non la legge nessuno, e' "
             "interfaccia o diagnostica."
@@ -821,16 +852,21 @@ def test_nessun_messaggio_di_log_ha_la_forma_del_protocollo():
     Il canale non protegge: il bridge unisce stderr a stdout. A separare la
     diagnostica dal protocollo resta solo la forma della riga, e questa e' la
     guardia che la tiene separata.
+
+    Le forme sono **due**, come per le `print()`. Guardare la sola `[CACHE]`
+    lasciava scoperta proprio quella che il logger scrive con piu' naturalezza:
+    `log.debug("    %s", path)` — sola indentazione piu' un path — chiude
+    nell'editor lo stream in volo, e lo chiude *prima* che sia finito.
     """
     colpevoli = []
     for rel in _moduli_pge():
         for originale, normalizzato in _messaggi_di_log(
                 ast.parse(_sorgente(rel))):
-            if _ha_forma_cache(normalizzato):
+            if _ha_forma_di_protocollo(normalizzato):
                 colpevoli.append(f"{rel}: {originale!r}")
 
     assert not colpevoli, (
-        "questi messaggi di log hanno la forma che PGE-ui parsa come stream, "
+        "questi messaggi di log hanno una delle due forme che PGE-ui parsa, "
         "e stderr NON e' un riparo (il bridge lo unisce a stdout):\n  "
         + "\n  ".join(colpevoli)
         + "\nVedi docs/explanation/contratto-stdout.md, issue #178."
@@ -840,15 +876,27 @@ def test_nessun_messaggio_di_log_ha_la_forma_del_protocollo():
 def test_la_guardia_sui_messaggi_di_log_riconosce_i_segnaposto_di_logging():
     """`%s` conta come interpolazione, o la guardia e' cieca sul caso vero.
 
-    La riga che ha prodotto lo stream fantasma nella misura qui sopra e'
-    scritta con lo stile pigro di `logging` (`"...%s..."`, argomenti a parte),
-    non con una f-string. Cercare `{}` soltanto l'avrebbe lasciata passare.
+    Le righe di `logging` si scrivono con lo stile pigro (`"...%s..."`,
+    argomenti a parte), non con una f-string, e `_messaggi_di_log` le riduce
+    percio' alla stessa forma `{}` delle `print()`.
+
+    Il caso che *misura* quella riduzione e' il blocco riassuntivo, non la
+    `[CACHE]`, e conviene dire perche': per `_RE_CACHE_LINE` il token e' `\\S+`,
+    e un `%s` lo soddisfa gia' cosi' com'e' — su quel ramo la normalizzazione
+    non cambia verdetto, e un test scritto solo su di esso resta verde anche
+    dopo averla tolta (misurato). La sagoma del path invece pretende che *tutto*
+    quel che non e' indentazione sia interpolazione: li' `    %s` senza
+    riduzione e' testo, e la guardia diventa cieca.
     """
     sorgente = (
         'log = get_diagnostic_logger()\n'
         'log.debug("[CACHE] %s: registrata", nome)\n'
+        'log.debug("    %s", path)\n'
     )
 
     messaggi = _messaggi_di_log(ast.parse(sorgente))
 
-    assert [_ha_forma_cache(n) for _, n in messaggi] == [True]
+    # Sui grezzi la seconda riga non e' riconoscibile: e' la riduzione a
+    # renderla tale, ed e' questa la differenza che il test misura.
+    assert [_ha_forma_di_protocollo(o) for o, _ in messaggi] == [True, False]
+    assert [_ha_forma_di_protocollo(n) for _, n in messaggi] == [True, True]

--- a/tests/shared/test_stdout_contract.py
+++ b/tests/shared/test_stdout_contract.py
@@ -24,14 +24,21 @@ asserzione di comportamento — solo questa); rimettere un `print()` in
 `strategies/` riapre in silenzio la porta che la #187 ha chiuso.
 
 **Chi emette la riga non e' solo un renderer.** I tre renderer la stampano
-sul percorso diretto (uno stream alla volta), ma la pipeline in due stadi
-passa da `Generator.write_sco_files`, che delega a
-`StreamCacheManager.get_dirty_stream_dicts`: e' li' che la riga esce, per
-tutti gli stream in blocco, prima che un renderer veda alcunche'. E' anche
-l'emettitore piu' esposto: il suo modulo contiene *altri* `print()` che la
-#178 non ha ancora classificato, quindi e' il prossimo su cui passera' un
-giro di conversione al logger, e chi lo fara' avra' sotto gli occhi righe
-`[CACHE]` di due nature diverse. Percio' sta nella lista come gli altri.
+sul percorso diretto, uno stream alla volta; il quarto emettitore e'
+`StreamCacheManager.get_dirty_stream_dicts`, che la stampa per tutti gli
+stream in blocco prima che un renderer esista.
+
+Quel quarto pero' e' **irraggiungibile**, e la #178 l'ha accertato: il suo
+unico chiamante e' `Generator.generate_score_files_per_stream`, che di
+chiamanti non ne ha (`tests/test_api_stdout.py` elenca entrambi fra gli
+irraggiungibili). Sta nella lista lo stesso, e la ragione e' quella per cui
+la lista esiste: la riga ha la forma del protocollo, quindi il giorno che
+qualcuno ricollega quel percorso arriva al parser dell'editor senza che
+nessuno debba deciderlo di nuovo. Il prezzo di tenercelo e' nullo; quello di
+toglierlo si paga una volta sola, tardi.
+
+Il metodo di `Generator` si chiama cosi': la prosa di questo file diceva
+`write_sco_files`, che non esiste in `src/pge/` e non e' mai esistito.
 
 **E i punti di registrazione non stanno tutti in `strategies/`.** Sono sette,
 e il settimo — `register_window_strategy` — vive in
@@ -62,16 +69,21 @@ per stream — e non la definizione di cosa il parser a valle legge. Vedi
 """
 import ast
 import os
+import re
+import sys
+from unittest.mock import patch
 
 import pytest
+
+from tests.main_mocks import mocks  # noqa: F401  (fixture pytest)
 
 SRC_PGE = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '..', '..', 'src', 'pge'))
 
 # I moduli che dichiarano all'editor lo stato della cache, stream per stream.
-# I tre renderer sul percorso diretto; il cache manager sul percorso in due
-# stadi (`Generator.write_sco_files` -> `get_dirty_stream_dicts`), dove la riga
-# esce prima che un renderer esista.
+# I tre renderer sul percorso diretto; il cache manager dentro
+# `get_dirty_stream_dicts`, che oggi nessuno raggiunge (vedi il docstring) ma
+# la cui riga ha la forma del protocollo.
 MODULI_CON_PROTOCOLLO_CACHE = [
     os.path.join('rendering', 'numpy_audio_renderer.py'),
     os.path.join('rendering', 'csound_renderer.py'),
@@ -349,3 +361,494 @@ def test_la_registrazione_dinamica_non_stampa(relpath):
             f"{relpath}: {funzione.name}() e' tornata a stampare. La conferma "
             "va a `log_strategy_registration` (issue #187), non su stdout."
         )
+
+
+# =============================================================================
+# 3. LA SECONDA RIGA DI PROTOCOLLO — il blocco riassuntivo
+# =============================================================================
+# Le righe che PGE-ui trasforma in eventi sono **due**, non una, e fin qui
+# questo file ne sorvegliava una sola. L'altra e' il blocco riassuntivo di
+# `cli.py`: `print(f"    {path}")` sotto «Generazione completata! N file
+# generati:». Da li' `parse_render_line` ricava lo `stream-done` dell'ultimo
+# stream DIRTY del giro — gli altri li chiude la riga `[CACHE]` successiva,
+# l'ultimo non ha nessuna riga dopo di se'. Toglierle l'indentazione, o
+# spezzarla su piu' righe, lascia quell'unico stem col pallino giallo dopo un
+# render che ha fatto esattamente cio' che il pallino chiedeva.
+#
+# Misurato per sabotaggio: passando da `f"    {path}"` a `f"{path}"` la suite
+# di PGE restava interamente verde prima di questo test.
+#
+# Qui la guardia e' **di comportamento** e non una lettura dei sorgenti: si
+# fa scrivere alla CLI il suo riepilogo e si guardano i byte che finiscono su
+# stdout, che sono esattamente quelli che PGE-ui legge. Un `print()` letto
+# con `ast` direbbe che la riga esiste; solo l'output dice che esce indentata.
+
+# Trascritta da `render_pipeline._RE_STEM_PATH` di PGE-ui. La trascrizione e'
+# inevitabile — l'altro repo non e' importabile da qui — ed e' il motivo per
+# cui il doc del contratto la nomina: se cambia di la', questa va aggiornata,
+# ed e' un cambio di superficie pubblica con analisi d'impatto.
+FORMA_PROTOCOLLO_PATH = re.compile(
+    r"^\s+(.+__.+)\.(?:aif|aiff|wav|flac)\s*$", re.IGNORECASE)
+
+
+# E questa e' `_RE_CACHE_LINE`, sempre di PGE-ui. Non e' un doppione di
+# `PREFISSO_PROTOCOLLO_CACHE`: quella e' la guardia *stretta* che difende la
+# riga per stream (pretende un `{}` in prima posizione), questa e' cio' che il
+# parser davvero legge — un token qualunque senza spazi, letterale compreso.
+# La differenza fra le due e' esattamente lo spazio in cui vivono
+# `[CACHE] Manifest:` e `[CACHE] GC:`, che l'editor matcha e poi scarta col
+# filtro sugli id dichiarati.
+FORMA_PROTOCOLLO_CACHE = re.compile(r"^\[CACHE\]\s+(\S+):\s+(.+)$")
+
+
+def _ha_forma_cache(forma):
+    """La riga entrerebbe in `_RE_CACHE_LINE` di PGE-ui.
+
+    Si misura sulla forma con le interpolazioni ridotte a un token: un id di
+    stream e una parola letterale sono indistinguibili per quella regex, che
+    e' il punto.
+    """
+    return forma is not None and bool(
+        FORMA_PROTOCOLLO_CACHE.match(forma.replace('{}', 'x')))
+
+
+def _ha_forma_di_path(forma):
+    """La riga e' fatta di sola indentazione piu' un valore interpolato.
+
+    E' la forma del blocco riassuntivo, l'altra meta' del protocollo. Qui la
+    lettura statica arriva fino a un certo punto e conviene dirlo: se il path
+    finisca o no in `.wav` lo decide il valore a runtime, non il sorgente.
+    Percio' la direzione "questa riga e' protocollo" la misura il test di
+    comportamento della sezione 3; questa funzione riconosce solo la *sagoma*
+    — indentazione piu' interpolazione e nient'altro — che e' cio' che rende
+    una riga candidata a essere letta come path di uno stem.
+    """
+    return (forma is not None and forma[:1].isspace()
+            and forma.replace('{}', '').strip() == '')
+
+
+def _stem_paths_su_stdout(testo):
+    """Le righe di `testo` che PGE-ui leggerebbe come path di uno stem."""
+    return [FORMA_PROTOCOLLO_PATH.match(r).group(1)
+            for r in testo.splitlines()
+            if FORMA_PROTOCOLLO_PATH.match(r)]
+
+
+def test_il_blocco_riassuntivo_resta_protocollo(mocks, capsys):
+    """I path degli stem escono nella forma da cui PGE-ui ricava stream-done.
+
+    E' la seconda meta' del protocollo, e l'unica che chiude l'ultimo stream
+    DIRTY del giro.
+    """
+    api_mod = mocks['main'].api
+    result = api_mod.RenderResult(
+        audio_paths=['/out/PGE_test__streamA.wav',
+                     '/out/PGE_test__stream-B.2.wav'],
+        elapsed_seconds=0.0, renderer_type='numpy', per_stream=True)
+    argv = ['main.py', 'test.yml', 'out.wav', '--per-stream',
+            '--renderer', 'numpy', '--format', 'wav']
+    with patch.object(api_mod, 'render', return_value=result):
+        with patch.object(sys, 'argv', argv):
+            mocks['main'].main()
+
+    trovati = _stem_paths_su_stdout(capsys.readouterr().out)
+
+    assert trovati == ['/out/PGE_test__streamA', '/out/PGE_test__stream-B.2'], (
+        "il blocco riassuntivo non esce piu' nella forma che PGE-ui parsa "
+        "(`    <path>__<id>.<ext>`). E' da li' che l'editor ricava lo "
+        "stream-done dell'ultimo stream DIRTY: vedi issue #178 e "
+        "docs/explanation/contratto-stdout.md."
+    )
+
+
+def test_lo_stream_done_si_aggancia_al_suffisso_dell_id(mocks, capsys):
+    """Il path deve finire per `__<id>`, che e' cio' che PGE-ui confronta.
+
+    `parse_render_line` non cattura l'id: chiede che il path finisca per
+    `"__" + <lo stream in corso>`. Un id troncato o normalizzato nel path — un
+    `.`/`-` sostituito, il basename accorciato — lascia il confronto senza
+    aggancio, e lo stream in volo non si chiude mai. E' lo stesso difetto che
+    la `\\w` nella regex a monte aveva gia' prodotto una volta.
+    """
+    api_mod = mocks['main'].api
+    result = api_mod.RenderResult(
+        audio_paths=['/out/PGE_test__stream-B.2.wav'],
+        elapsed_seconds=0.0, renderer_type='numpy', per_stream=True)
+    argv = ['main.py', 'test.yml', 'out.wav', '--per-stream',
+            '--renderer', 'numpy', '--format', 'wav']
+    with patch.object(api_mod, 'render', return_value=result):
+        with patch.object(sys, 'argv', argv):
+            mocks['main'].main()
+
+    trovati = _stem_paths_su_stdout(capsys.readouterr().out)
+
+    assert any(p.endswith('__stream-B.2') for p in trovati), (
+        "il path dello stem non finisce piu' per `__<id>`: PGE-ui confronta "
+        "proprio quel suffisso per chiudere lo stream in corso."
+    )
+
+
+# =============================================================================
+# 4. LA CLASSIFICAZIONE COMPLETA — ogni print() di src/pge/ ha una categoria
+# =============================================================================
+# L'esito della #178 e' che *ogni* riga sappia in quale delle tre categorie
+# sta. Fin qui il repo ne classificava due gruppi — la riga `[CACHE]` per
+# stream (protocollo) e le registrazioni di strategy (diagnostica, #187) — e
+# per tutto il resto `api.py` diceva «nessuno le parsa, per quanto se ne sa»,
+# che e' la frase che questa issue doveva chiudere.
+#
+# La tabella e' la classificazione, in forma eseguibile. La chiave e'
+# **(modulo, forma della riga)**: il numero di riga si sposta a ogni modifica
+# del file, la forma no — e la forma e' anche cio' su cui il parser a valle
+# decide. Due `print()` con la stessa forma nello stesso modulo sono la stessa
+# riga, e condividono la categoria per costruzione.
+#
+# Le tre categorie sono per **destinatario**, non per contenuto:
+#
+#   PROTOCOLLO   il parser di PGE-ui la legge. Resta su stdout, con quella
+#                forma esatta. Cambiarla e' superficie pubblica.
+#   DIAGNOSTICA  la legge chi sta estendendo il motore. Puo' andare al logger.
+#   INTERFACCIA  la legge a schermo chi ha lanciato il render. Resta su
+#                stdout, ma non e' protocollo: nessuno la parsa.
+#
+# Il criterio fra le ultime due, che e' l'unico che richiede un giudizio:
+# **di chi parla la riga.** Del render di chi ha lanciato il comando — cosa
+# sta producendo, quanto ci ha messo, dove sono i file, cosa non andava nel
+# suo YAML — o della contabilita' interna del motore. `⚡ SOLO MODE` e
+# `🔇 N stream muted` sono interfaccia benche' somiglino a debug: dicono al
+# compositore che il suo flag ha cambiato l'audio che sta per ascoltare.
+#
+# **Cosa la tabella non decide.** Dice dove una riga *sta*, non dove dovrebbe
+# andare: spostare una INTERFACCIA al logger resta una scelta di prodotto —
+# cambia cio' che l'utente vede — e le issue di esecuzione la prendono una
+# riga alla volta. Quel che la tabella impedisce e' di spostarne una senza
+# accorgersi che era protocollo.
+PROTOCOLLO = 'protocollo'
+DIAGNOSTICA = 'diagnostica'
+INTERFACCIA = 'interfaccia'
+
+CLASSIFICAZIONE = {
+    # --- cli.py ---
+    ('cli.py', '\n Generazione completata! {} file generati:'):
+        INTERFACCIA,
+    ('cli.py', '\n Rendering completato in {}s{}'):
+        INTERFACCIA,
+    ('cli.py', '\nGenerazione partitura grafica...'):
+        INTERFACCIA,
+    ('cli.py', '    {}'):
+        PROTOCOLLO,
+    ('cli.py', '  Dettagli:     {}'):
+        INTERFACCIA,
+    ('cli.py', '  → {}: grani non generati (cache)'):
+        INTERFACCIA,
+    ('cli.py', '  → {}: {} {} ({} {})'):
+        INTERFACCIA,
+    ('cli.py', ' Errore: {}'):
+        INTERFACCIA,
+    ('cli.py', "--grain-height non valido: '{}'. Valori: {}"):
+        INTERFACCIA,
+    ('cli.py', '--jobs deve essere >= 1, ricevuto: {}. Usa 1 per il rendering sequenziale.'):
+        INTERFACCIA,
+    ('cli.py', "--jobs non valido: '{}'. Usa un intero >= 1 oppure 'auto'."):
+        INTERFACCIA,
+    ('cli.py', '--log-dir richiede una directory. Esempio: --log-dir /percorso/ai/log'):
+        INTERFACCIA,
+    ('cli.py', "--magnify-at: chiave ignota '{}'. Valide: {}."):
+        INTERFACCIA,
+    ('cli.py', '--magnify-at: nessun target valido nello SPEC.'):
+        INTERFACCIA,
+    ('cli.py', "--magnify-at: ogni target richiede la chiave 't' (tempo in secondi)."):
+        INTERFACCIA,
+    ('cli.py', "--magnify-at: token non valido '{}'. Usa chiave=valore (es. t=14,zoom=10)."):
+        INTERFACCIA,
+    ('cli.py', "--magnify-at: valore non numerico per '{}': '{}'."):
+        INTERFACCIA,
+    ('cli.py', '--page-duration deve essere positivo, ricevuto: {}'):
+        INTERFACCIA,
+    ('cli.py', "--page-duration non valido: '{}'. Deve essere un numero."):
+        INTERFACCIA,
+    ('cli.py', '--samples-dir richiede una directory. Esempio: --samples-dir /percorso/ai/sample'):
+        INTERFACCIA,
+    ('cli.py', '--sc-block-size deve essere >= 1, ricevuto: {}'):
+        INTERFACCIA,
+    ('cli.py', "--sc-block-size non valido: '{}'. Deve essere un intero >= 1."):
+        INTERFACCIA,
+    ('cli.py', '--sc-max-nodes deve essere >= 1, ricevuto: {}'):
+        INTERFACCIA,
+    ('cli.py', "--sc-max-nodes non valido: '{}'. Deve essere un intero >= 1."):
+        INTERFACCIA,
+    ('cli.py', "--sv-layout non valido: '{}'. Valori: multi, single"):
+        INTERFACCIA,
+    ('cli.py', 'Caricamento {}...'):
+        INTERFACCIA,
+    ('cli.py', 'Envelope non validi: {}. Validi: {}'):
+        INTERFACCIA,
+    ('cli.py', "Formato non supportato: '{}'. Usa: aiff, wav, flac"):
+        INTERFACCIA,
+    ('cli.py', 'Generazione streams...'):
+        INTERFACCIA,
+    ('cli.py', 'Grain JSON: {}'):
+        INTERFACCIA,
+    ('cli.py', 'Log: {}'):
+        INTERFACCIA,
+    ('cli.py', 'Reaper project: {}'):
+        INTERFACCIA,
+    ('cli.py', 'Sonic Visualiser session: {}'):
+        INTERFACCIA,
+    ('cli.py', 'Uso: python main.py <file.yml> [output.aif] [--visualize] [--show-static] [--show-voice-offsets] [--plot-envelopes nomi,csv] [--magnify] [--magnify-at SPEC] [--page-duration SECONDI] [--grain-height duration|read-span] [--bw] [--per-stream] [--renderer csound|numpy|supercollider] [--jobs N|auto] [--format aiff|wav|flac] [--samples-dir DIR] [--log-dir DIR] [--orc-path PATH] [--incdir DIR] [--ssdir DIR] [--sfdir DIR] [--message-level N] [--keep-sco] [--sco-dir DIR] [--sc-synthdef-source PATH] [--sc-synthdef-dir DIR] [--sc-block-size N] [--sc-max-nodes N] [--keep-osc] [--osc-dir DIR] [--cache] [--cache-dir DIR] [--reaper] [--reaper-path FILE] [--grain-json] [--export-sv] [--sv-path FILE] [--sv-layout multi|single]'):
+        INTERFACCIA,
+    ('cli.py', '[CACHE] GC: rimossi {} stream orfani: {}'):
+        PROTOCOLLO,
+    ('cli.py', '[CACHE] Manifest: {}'):
+        PROTOCOLLO,
+    ('cli.py', '[export-sv] ignorato in modalità --per-stream (STEMS): v1 supporta solo MIX'):
+        INTERFACCIA,
+    ('cli.py', '[grain-json] ignorato: richiede --per-stream'):
+        INTERFACCIA,
+    ('cli.py', None):
+        INTERFACCIA,
+    # --- engine/generator.py ---
+    ('engine/generator.py', "  → Stream '{}': {}"):
+        DIAGNOSTICA,
+    ('engine/generator.py', 'Creazione di {} stream...'):
+        INTERFACCIA,
+    ('engine/generator.py', '[CACHE] Stream da scrivere: {}'):
+        DIAGNOSTICA,
+    ('engine/generator.py', "[SEED] Nessun seed nello YAML: seed di sessione {}. Per riprodurre questo run aggiungi 'seed: {}' allo YAML."):
+        INTERFACCIA,
+    ('engine/generator.py', "⚠️  Warning: impossibile valutare '{}': {}"):
+        INTERFACCIA,
+    ('engine/generator.py', '⚡ SOLO MODE: creazione di {} stream (su {} totali)'):
+        INTERFACCIA,
+    ('engine/generator.py', '🔇 {} stream muted'):
+        INTERFACCIA,
+    # --- rendering/csound_renderer.py ---
+    ('rendering/csound_renderer.py', '[CACHE] {}: {}'):
+        PROTOCOLLO,
+    # --- rendering/numpy_audio_renderer.py ---
+    ('rendering/numpy_audio_renderer.py', '[CACHE] {}: {}'):
+        PROTOCOLLO,
+    # --- rendering/score_visualizer.py ---
+    ('rendering/score_visualizer.py', '  Rendering pagina {}/{}...'):
+        INTERFACCIA,
+    ('rendering/score_visualizer.py', '  ✓ {}'):
+        INTERFACCIA,
+    ('rendering/score_visualizer.py', 'Analisi completata: {} pagine, durata totale {}s'):
+        INTERFACCIA,
+    ('rendering/score_visualizer.py', 'Esportazione PDF: {}'):
+        INTERFACCIA,
+    ('rendering/score_visualizer.py', 'Esportazione PNG in: {}'):
+        INTERFACCIA,
+    ('rendering/score_visualizer.py', '⚠️  Impossibile caricare waveform {}: {}'):
+        INTERFACCIA,
+    ('rendering/score_visualizer.py', '✓ PDF esportato: {}'):
+        INTERFACCIA,
+    # --- rendering/score_writer.py ---
+    ('rendering/score_writer.py', '  - {} function tables'):
+        INTERFACCIA,
+    ('rendering/score_writer.py', '  - {} grani totali'):
+        INTERFACCIA,
+    ('rendering/score_writer.py', '  - {} streams granulari'):
+        INTERFACCIA,
+    ('rendering/score_writer.py', '✓ Score generato: {}'):
+        INTERFACCIA,
+    # --- rendering/stream_cache_manager.py ---
+    ('rendering/stream_cache_manager.py', '[CACHE] {}/{} stream da ricompilare'):
+        INTERFACCIA,
+    ('rendering/stream_cache_manager.py', '[CACHE] {}: {}'):
+        PROTOCOLLO,
+    # --- rendering/supercollider_renderer.py ---
+    ('rendering/supercollider_renderer.py', '[CACHE] {}: {}'):
+        PROTOCOLLO,
+    # --- shared/logger.py ---
+    ('shared/logger.py', 'CLIP: {}'):
+        INTERFACCIA,
+    ('shared/logger.py', '📝 Clip log file: {}'):
+        INTERFACCIA,
+}
+
+
+def _print_censiti():
+    """Le `print()` di `src/pge/`, come (modulo, forma del primo argomento).
+
+    `None` come forma e' un primo argomento che non e' una stringa letterale
+    — `print(err.user_message())` — dove non c'e' nessun testo da leggere
+    staticamente: entra comunque nel censimento, perche' la domanda della
+    #178 e' «questa riga chi la legge», non «che forma ha».
+    """
+    censiti = set()
+    for rel in _moduli_pge():
+        for chiamata in _print_calls(ast.parse(_sorgente(rel))):
+            forma = _template(chiamata.args[0]) if chiamata.args else None
+            if chiamata.args and not isinstance(
+                    chiamata.args[0], (ast.Constant, ast.JoinedStr)):
+                forma = None
+            censiti.add((rel, forma))
+    return censiti
+
+
+def test_ogni_print_di_src_pge_e_classificato():
+    """Nessuna `print()` senza categoria, nessuna categoria senza `print()`.
+
+    Le due direzioni servono entrambe, come per le liste della #187. Una
+    `print()` nuova che nessuno classifica e' il modo in cui il canale e'
+    tornato ambiguo la prima volta: chi la scrive non sa che sta scrivendo
+    dentro l'interfaccia di un altro repository, e niente glielo dice. Una
+    voce che resta in tabella dopo che la riga se n'e' andata al logger
+    trasforma la classificazione in un ricordo — ed e' esattamente cio' che
+    succedera' quando le issue di esecuzione cominceranno a spostarle.
+    """
+    trovati = _print_censiti()
+    dichiarati = set(CLASSIFICAZIONE)
+
+    assert trovati == dichiarati, (
+        "la classificazione di stdout non e' piu' allineata ai sorgenti.\n"
+        f"  da classificare: {sorted(trovati - dichiarati)}\n"
+        f"  non piu' emesse: {sorted(dichiarati - trovati)}\n"
+        "Ogni print() di src/pge/ va in CLASSIFICAZIONE come protocollo, "
+        "diagnostica o interfaccia: vedi issue #178 e "
+        "docs/explanation/contratto-stdout.md."
+    )
+
+
+def _classificazione_ordinata():
+    """Le voci in ordine stabile. La chiave regge la forma `None`, che
+    `sorted` da sola non sa confrontare con una stringa."""
+    return sorted(CLASSIFICAZIONE.items(),
+                  key=lambda voce: (voce[0][0], voce[0][1] is None, voce[0][1] or ''))
+
+
+def test_solo_le_righe_di_protocollo_hanno_forma_di_protocollo():
+    """Nessuna riga classificata altrimenti entra nel parser di PGE-ui.
+
+    E' la meta' che rende la tabella qualcosa di piu' di un elenco. Le due
+    forme che `render_pipeline.py` riconosce sono uno spazio di nomi
+    condiviso: chiunque scriva `[CACHE] <token>: ...` ci finisce dentro,
+    qualunque cosa intendesse dire. Classificare una riga come interfaccia
+    non la tiene fuori dal parser — solo la sua forma lo fa.
+    """
+    for (modulo, forma), categoria in _classificazione_ordinata():
+        if categoria == PROTOCOLLO or forma is None:
+            continue
+        assert not _ha_forma_cache(forma), (
+            f"{modulo}: `{forma}` e' classificata {categoria} ma ha la forma "
+            "che PGE-ui parsa come stream. O e' protocollo, o va riscritta.\n"
+            "Il prefisso `[CACHE] <token>: ` finisce nel parser dell'editor "
+            "qualunque cosa la riga intenda dire: vedi issue #178."
+        )
+
+
+def test_le_righe_di_protocollo_sono_quelle_che_il_parser_legge():
+    """La categoria PROTOCOLLO non e' piu' larga di cio' che il parser vede.
+
+    L'inclusione va tenuta nelle due direzioni, e questa e' quella che si
+    perde: marcare protocollo una riga che nessuno parsa la congela senza
+    motivo — e chi legge la tabella per sapere cosa non puo' toccare si
+    ritrova a difendere prosa. Le forme ammesse sono due, e sono le due che
+    `render_pipeline.py` riconosce.
+    """
+    for (modulo, forma), categoria in _classificazione_ordinata():
+        if categoria != PROTOCOLLO:
+            continue
+        assert forma is not None, f"{modulo}: protocollo senza forma leggibile"
+        parsata = _ha_forma_cache(forma) or _ha_forma_di_path(forma)
+        assert parsata, (
+            f"{modulo}: `{forma}` e' marcata protocollo ma non ha nessuna "
+            "delle due forme che PGE-ui parsa. Se non la legge nessuno, e' "
+            "interfaccia o diagnostica."
+        )
+
+
+# =============================================================================
+# 5. NEMMENO IL LOGGER PUO' PARLARE COME IL PROTOCOLLO
+# =============================================================================
+# `logger.py` e questo file hanno scritto a lungo che la diagnostica e' al
+# sicuro perche' `logging` scrive su **stderr** e il protocollo vive su
+# stdout. Il file descriptor pero' non e' un confine: il bridge di PGE-ui
+# lancia il motore con `stderr=subprocess.STDOUT` (`RenderState.start`), quindi
+# stderr e stdout arrivano allo stesso `readline`, e ogni riga passa per
+# `parse_render_line`.
+#
+# Misurato, non dedotto. Con l'host che accende la diagnostica come chiunque
+# la accenderebbe:
+#
+#     logging.basicConfig(level=logging.DEBUG, format="%(message)s")
+#     logging.getLogger('pge.diagnostics').debug("[CACHE] %s: registrata", nome)
+#
+# la riga e' arrivata al parser tale e quale e ha prodotto `stream-start` +
+# `stream-done` per uno stream di nome `gaussian`, che non esiste. A salvarla
+# nel formato di default e' solo il prefisso `DEBUG:pge.diagnostics:` che il
+# formatter antepone — cioe' una scelta dell'host, non una garanzia del
+# motore: `format="%(message)s"` la toglie.
+#
+# Quindi la regola vera non e' «il logger e' un altro canale». E':
+# **nessuno, su nessun canale, scrive righe che hanno la forma del
+# protocollo.** Il censimento delle `print()` non basta a tenerla, perche' una
+# riga che nasce gia' sul logger non e' una `print()`.
+
+METODI_LOG = {'debug', 'info', 'warning', 'warn', 'error',
+              'exception', 'critical', 'log'}
+
+
+def _messaggi_di_log(tree):
+    """I messaggi letterali passati a una chiamata di logging.
+
+    Riconosce la forma `<qualcosa>.debug("...")` per attributo, senza
+    risolvere chi sia l'oggetto: un logger vero, `self.logger`, il risultato
+    di `get_diagnostic_logger()` sono tutti la stessa domanda. `.log(livello,
+    msg)` porta il messaggio in seconda posizione.
+    """
+    messaggi = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in METODI_LOG):
+            continue
+        args = node.args[1:] if node.func.attr == 'log' else node.args
+        if not args:
+            continue
+        forma = _template(args[0])
+        if forma:
+            # I segnaposto di `logging` sono `%s`/`%d`, non `{}`: qui contano
+            # come interpolazioni esattamente come quelli di una f-string.
+            messaggi.append((forma, re.sub(r'%[sdrfgi]', '{}', forma)))
+    return messaggi
+
+
+def test_nessun_messaggio_di_log_ha_la_forma_del_protocollo():
+    """Nessuna riga di logging entrerebbe nel parser di PGE-ui.
+
+    Il canale non protegge: il bridge unisce stderr a stdout. A separare la
+    diagnostica dal protocollo resta solo la forma della riga, e questa e' la
+    guardia che la tiene separata.
+    """
+    colpevoli = []
+    for rel in _moduli_pge():
+        for originale, normalizzato in _messaggi_di_log(
+                ast.parse(_sorgente(rel))):
+            if _ha_forma_cache(normalizzato):
+                colpevoli.append(f"{rel}: {originale!r}")
+
+    assert not colpevoli, (
+        "questi messaggi di log hanno la forma che PGE-ui parsa come stream, "
+        "e stderr NON e' un riparo (il bridge lo unisce a stdout):\n  "
+        + "\n  ".join(colpevoli)
+        + "\nVedi docs/explanation/contratto-stdout.md, issue #178."
+    )
+
+
+def test_la_guardia_sui_messaggi_di_log_riconosce_i_segnaposto_di_logging():
+    """`%s` conta come interpolazione, o la guardia e' cieca sul caso vero.
+
+    La riga che ha prodotto lo stream fantasma nella misura qui sopra e'
+    scritta con lo stile pigro di `logging` (`"...%s..."`, argomenti a parte),
+    non con una f-string. Cercare `{}` soltanto l'avrebbe lasciata passare.
+    """
+    sorgente = (
+        'log = get_diagnostic_logger()\n'
+        'log.debug("[CACHE] %s: registrata", nome)\n'
+    )
+
+    messaggi = _messaggi_di_log(ast.parse(sorgente))
+
+    assert [_ha_forma_cache(n) for _, n in messaggi] == [True]


### PR DESCRIPTION
## Sommario

Completamento della #178: accertamento eseguibile che ogni `print()` di `src/pge/` abbia una categoria (protocollo / diagnostica / interfaccia CLI), e che nessuna riga di logging abbia la forma che PGE-ui parsa.

La #178 aveva accertato il ruolo della riga `[CACHE] <id>: DIRTY|clean` (protocollo). Questa PR estende l'accertamento alla **seconda riga di protocollo** — il blocco riassuntivo di `cli.py` — e introduce una **classificazione completa e eseguibile** di tutte le 64 `print()` del motore.

## Cambiamenti principali

### Test (`tests/shared/test_stdout_contract.py`)

- **Sezione 3 (nuova):** test di comportamento sul blocco riassuntivo
  - `test_il_blocco_riassuntivo_resta_protocollo`: verifica che i path degli stem escano nella forma `    <path>__<id>.<ext>` che PGE-ui parsa come `stream-done` dell'ultimo stream DIRTY
  - `test_lo_stream_done_si_aggancia_al_suffisso_dell_id`: verifica che il path finisca per `__<id>` esatto (non normalizzato)
  - Helper: `_stem_paths_su_stdout()`, `_ha_forma_di_path()`, regex `FORMA_PROTOCOLLO_PATH`

- **Sezione 4 (nuova):** classificazione completa e test di coerenza
  - `CLASSIFICAZIONE`: tabella eseguibile di 64 voci `(modulo, forma) → categoria`
  - `test_ogni_print_di_src_pge_e_classificato`: verifica bidirezionale (nessuna riga senza categoria, nessuna categoria senza riga)
  - `test_solo_le_righe_di_protocollo_hanno_forma_di_protocollo`: nessuna riga non-protocollo entra in `_RE_CACHE_LINE`
  - `test_le_righe_di_protocollo_sono_quelle_che_il_parser_legge`: nessuna riga protocollo senza forma parsabile
  - Helper: `_classificazione_ordinata()`, `_print_censiti()` (lettura AST)

- **Sezione 5 (nuova):** guardia su logging
  - `test_nessun_messaggio_di_log_ha_la_forma_del_protocollo`: nessun record di logging entra in `_RE_CACHE_LINE` (stderr non è un riparo: il bridge unisce i flussi)
  - `test_la_guardia_sui_messaggi_di_log_riconosce_i_segnaposto_di_logging`: verifica che `%s`/`%d` siano riconosciuti come interpolazioni
  - Helper: `_messaggi_di_log()` (lettura AST), `METODI_LOG`

### Documentazione (`docs/explanation/contratto-stdout.md`)

- **Sezione "Modello":** riscritta per chiarire che le tre categorie sono per destinatario, non per contenuto
- **Sezione "Chi parsa, e cosa" (nuova):** tabella delle due forme riconosciute da `render_pipeline.py` con regex e evento corrispondente; nota su tre righe riconosciute solo per colorazione
- **Sezione "Le due righe di protocollo" (nuova):** dettaglio su `[CACHE] <id>: DIRTY|clean` e blocco riassuntivo; chiarimento su `StreamCacheManager.get_dirty_stream_dicts` irraggiungibile
- **Sezione "La forma non dice l'intenzione" (nuova):** collisioni di forma (`Manifest`/`GC`, path di

https://claude.ai/code/session_01P7gXhCyybysUCFE7K2d69U