### PR TITLE
feat: grain.duration_range come frazione della durata del grano (#267)

### DIFF
--- a/.claude/rules/cross-repo-impact.md
+++ b/.claude/rules/cross-repo-impact.md
@@ -1,31 +1,56 @@
-# Impatto cross-repo su PGE-ls e PGE-ui
+# Impatto cross-repo su PGE-ls, PGE-ui e gl-ls
 
-PGE non vive isolato. Due repo dipendono dalla sua superficie pubblica:
+PGE non vive isolato. Tre repo dipendono dalla sua superficie pubblica:
 
 - `PGE-ls` (github.com/DMGiulioRomano/PGE-ls) — language server (pygls) che
   edita/valida lo YAML del granular engine.
 - `PGE-ui` (github.com/DMGiulioRomano/PGE-ui) — interfaccia utente del granular
   engine.
+- `gl-ls` (github.com/DMGiulioRomano/gl-ls) — language server degli `study.yml`
+  di `granulation-studies`, che **incapsulano** la superficie YAML di PGE: il
+  blocco `base:` di uno studio e' un blocco stream engine. Ne tiene percio' un
+  mirror proprio — registry di chiavi per contesto (`schema.py`, dove
+  `grain`/`pointer`/`pitch`/`voices` hanno vocabolario **chiuso**: una chiave
+  che il registry non conosce diventa `unknown-key` con quick fix di rename),
+  bounds dei parametri e delle bande (`engine_info.py`), e la riscrittura delle
+  unita' che l'engine fa al parse (`diagnostics._UNIT_SCALED`, mirror di
+  `Stream._pre_normalize_grain_params`).
+
+Le tre superfici non coincidono, e la copertura di una non implica quella delle
+altre: una chiave nuova dentro un blocco engine resta muta in PGE-ui finche'
+l'editor non la espone, ma in gl-ls e' **subito un falso rosso** su YAML
+valido, perche' li' il vocabolario e' chiuso per costruzione.
 
 ## Quando applicare
 
 Per OGNI feature, modifica o fix che tocca una superficie osservabile da quei
-repo: sintassi/schema YAML, nuove chiavi o blocchi, bounds dei parametri, nomi
-di strategy/window/renderer, gerarchia errori, formati di output, CLI/flag,
-comportamento del rendering. Vale anche per refactoring che rinomina simboli
-pubblici o cambia messaggi d'errore parsati a valle.
+repo: sintassi/schema YAML, nuove chiavi o blocchi, bounds dei parametri e
+delle bande, nomi di strategy/window/renderer, gerarchia errori, formati di
+output, CLI/flag, comportamento del rendering. Vale anche per refactoring che
+rinomina simboli pubblici o cambia messaggi d'errore parsati a valle.
+
+Per `gl-ls` valgono in piu' due domande, perche' mirrora codice PGE invece di
+leggerlo dal vivo:
+
+- la chiave nuova va aggiunta al registry del suo contesto? (altrimenti
+  `unknown-key` piu' un rename che riscrive YAML corretto);
+- la modifica cambia **se** o **come** l'engine riscala/valida un valore al
+  parse? (allora il mirror in `diagnostics.py` divergerebbe in silenzio).
 
 ## Procedura
 
 1. Identifica cosa cambia nella superficie pubblica (YAML, errori, CLI, formati).
 2. Verifica se `PGE-ls` deve aggiornarsi (autocomplete, validazione, hover,
-   diagnostica, snippet) e se `PGE-ui` deve aggiornarsi (controlli, form,
-   visualizzazioni, default).
+   diagnostica, snippet), se `PGE-ui` deve aggiornarsi (controlli, form,
+   visualizzazioni, default) e se `gl-ls` deve aggiornarsi (registry di chiavi,
+   bounds, mirror delle conversioni, hover).
 3. Se c'è impatto, apri una issue nel repo interessato — una per repo:
    ```bash
    gh issue create -R DMGiulioRomano/PGE-ls  --title ... --body ...
    gh issue create -R DMGiulioRomano/PGE-ui  --title ... --body ...
+   gh issue create -R DMGiulioRomano/gl-ls   --title ... --body ...
    ```
    La issue descrive la modifica PGE, il riferimento (issue/PR), e cosa va
    aggiornato.
-4. Se non c'è impatto, dichiaralo esplicitamente nel riepilogo (niente issue).
+4. Se non c'è impatto, dichiaralo esplicitamente nel riepilogo (niente issue) —
+   repo per repo, non in blocco.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,13 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   col `Parameter` che la rimisura a ogni grano: il tetto al parse e la banda a
   runtime sono due letture della stessa banda e devono coincidere per
   costruzione — scritte separatamente divergevano già su una base negativa,
-  dove il prodotto scende mentre la banda sale.
+  dove il prodotto scende mentre la banda sale. Su una base envelope il tetto
+  si misura su **ogni** breakpoint e non sul solo picco: la banda relativa
+  cresce con la base solo finché la frazione sta sotto 1, e valutarla in un
+  punto solo avrebbe legato il controllo al tetto di `RELATIVE_RANGE_BOUNDS`
+  senza dirlo — cioè avrebbe reso «allargare il dominio», che è
+  retrocompatibile ovunque, l'unica mossa capace di rimettere il controllo a
+  tacere proprio dove esiste per parlare.
 
   Tre trappole chiuse esplicitamente. `duration_unit` **non** converte una
   frazione — convertirla renderebbe `duration_range: 0.5` sotto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,46 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- **`grain.duration_range` può essere una frazione della durata del grano**
+  (issue #267). La chiave `grain.duration_range_unit: absolute | relative`
+  (default `absolute`, quindi nessuno YAML esistente si rilegge diversamente)
+  dichiara in che cosa la larghezza della banda è misurata: nell'unità del
+  parametro, come sempre, oppure come frazione del valore base a
+  quell'istante — letta perciò *dopo* l'envelope della `duration`.
+
+  Serve dove la base spazia su più ordini di grandezza. Nello studio da cui la
+  issue nasce `grain.duration` va da 1 campione (~0.021 ms) a 500 ms: una banda
+  assoluta è molte volte la durata sui grani corti — dove poi il clamp a 1
+  campione la taglia — e percentualmente trascurabile sui lunghi, così che
+  lungo lo sweep il *carattere* della dispersione cambia da solo, pur non
+  avendo mosso `duration_range`. All'ascolto l'effetto dell'asse si confonde
+  con l'effetto collaterale del range. Con `relative` la dispersione resta
+  quella scritta: `0.5` è ±25% della durata corrente, a 1 ms come a 500 ms.
+
+  La frazione vive in `[0, 1]` — dominio della modalità, non del parametro — e
+  le due ancore la consumano diversamente: `center` dà ±50% al massimo,
+  `min` dà `[base, 2·base]`. Sotto `center` il pavimento della banda non scende
+  mai sotto `base/2`, cioè una banda relativa non può collassare sul minimo del
+  parametro, che è poi la ragione per cui esiste. Sotto `min` il controllo del
+  tetto al parse diventa moltiplicativo (`base · (1 + range)`): la somma
+  lasciava passare in silenzio proprio le bande larghe, perché sommava una
+  frazione a una durata.
+
+  Due trappole chiuse esplicitamente. `duration_unit` **non** converte una
+  frazione — convertirla renderebbe `duration_range: 0.5` sotto
+  `duration_unit: samples` un `0.5/48000` muto, senza errore né warning da
+  leggere nel file. E `duration_range_unit: relative` **senza**
+  `duration_range` è un `MissingFieldError` al parse, non una chiave inerte:
+  al posto della banda subentrerebbe il jitter implicito, che è assoluto,
+  cioè esattamente ciò che si stava cercando di evitare.
+
+  Il meccanismo è dichiarativo (`ParameterSpec.range_unit_path`) ma cablato
+  oggi sul solo `grain.duration_range`: è l'unico parametro la cui base spazia
+  per costruzione da 1 campione a 10 secondi, mentre su `volume` (dB) e `pan`
+  (gradi) la scala è già logaritmica o ciclica e una frazione della base non
+  direbbe la stessa cosa. `VARIATION_SEMANTICS_VERSION` non si muove: a chiave
+  assente la lettura è quella di prima.
+
 - **La guardia sugli `except` di `cli.py` copre anche cio' che il blocco della
   pipeline non contiene** (issue #257). La guardia strutturale leggeva i `try`
   che *contengono* `load_yaml()`, ed era la lettura giusta per il difetto che

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,12 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
   La frazione vive in `[0, 1]` — dominio della modalità, non del parametro — e
   le due ancore la consumano diversamente: `center` dà ±50% al massimo,
-  `min` dà `[base, 2·base]`. Sotto `center` il pavimento della banda non scende
-  mai sotto `base/2`, cioè una banda relativa non può collassare sul minimo del
-  parametro, che è poi la ragione per cui esiste. Sotto `min` il controllo del
+  `min` dà `[base, 2·base]`. Sotto `center` il pavimento è `base·(1 − r/2)` e
+  quindi si muove con la base invece di restare fermo — la ragione per cui la
+  modalità esiste — ma non è una garanzia di stare sopra il minimo del
+  parametro, che resta fisso: sotto `base < min_val / (1 − r/2)` (per
+  `grain_duration`, con `r = 1`, sotto i 2 campioni) è di nuovo il safety clamp
+  a tenere il pavimento. Sotto `min` il controllo del
   tetto al parse diventa moltiplicativo (`base · (1 + range)`): la somma
   lasciava passare in silenzio proprio le bande larghe, perché sommava una
   frazione a una durata.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,13 +35,18 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   lasciava passare in silenzio proprio le bande larghe, perché sommava una
   frazione a una durata.
 
-  Due trappole chiuse esplicitamente. `duration_unit` **non** converte una
+  Tre trappole chiuse esplicitamente. `duration_unit` **non** converte una
   frazione — convertirla renderebbe `duration_range: 0.5` sotto
   `duration_unit: samples` un `0.5/48000` muto, senza errore né warning da
-  leggere nel file. E `duration_range_unit: relative` **senza**
+  leggere nel file. `duration_range_unit: relative` **senza**
   `duration_range` è un `MissingFieldError` al parse, non una chiave inerte:
   al posto della banda subentrerebbe il jitter implicito, che è assoluto,
-  cioè esattamente ciò che si stava cercando di evitare.
+  cioè esattamente ciò che si stava cercando di evitare. E
+  `duration_range_unit` scritta e lasciata **vuota** è un
+  `InvalidFieldValueError`, non il default: assente vuol dire che nessuno ha
+  chiesto niente, vuota vuol dire che qualcuno ha scritto una riga che nessuno
+  legge — la stessa regola con cui la chiave gemella `grain.duration_unit`
+  rifiuta già una grafia vuota.
 
   Il meccanismo è dichiarativo (`ParameterSpec.range_unit_path`) ma cablato
   oggi sul solo `grain.duration_range`: è l'unico parametro la cui base spazia

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,14 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   parametro, che resta fisso: sotto `base < min_val / (1 − r/2)` (per
   `grain_duration`, con `r = 1`, sotto i 2 campioni) è di nuovo il safety clamp
   a tenere il pavimento. Sotto `min` il controllo del
-  tetto al parse diventa moltiplicativo (`base · (1 + range)`): la somma
-  lasciava passare in silenzio proprio le bande larghe, perché sommava una
-  frazione a una durata.
+  tetto al parse smette di sommare (`base + range · |base|`, cioè
+  `base · (1 + range)` su una base positiva): la somma lasciava passare in
+  silenzio proprio le bande larghe, perché sommava una frazione a una durata.
+  La larghezza viene da una funzione sola (`relative_band_width`), condivisa
+  col `Parameter` che la rimisura a ogni grano: il tetto al parse e la banda a
+  runtime sono due letture della stessa banda e devono coincidere per
+  costruzione — scritte separatamente divergevano già su una base negativa,
+  dove il prodotto scende mentre la banda sale.
 
   Tre trappole chiuse esplicitamente. `duration_unit` **non** converte una
   frazione — convertirla renderebbe `duration_range: 0.5` sotto

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,9 @@ Inspired by Barry Truax's DMX-1000 (1988).
 **Prima di modificare un modulo esistente:** esegui `/impact-analysis`.
 
 **Impatto cross-repo:** ogni modifica alla superficie pubblica (YAML, errori,
-CLI, formati) richiede analisi d'impatto su `PGE-ls` e `PGE-ui` ed eventuale
-apertura di issue. Regola completa: @.claude/rules/cross-repo-impact.md
+CLI, formati) richiede analisi d'impatto su `PGE-ls`, `PGE-ui` e `gl-ls` ed
+eventuale apertura di issue — una per repo, e la copertura di uno non implica
+quella degli altri. Regola completa: @.claude/rules/cross-repo-impact.md
 
 **Sync del paper CIM 2026:** quando una PR su PGE tocca qualcosa usato dagli
 esempi del paper (rendering, score visualizer, superficie usata da

--- a/docs/how-to/add-parameter.md
+++ b/docs/how-to/add-parameter.md
@@ -6,7 +6,7 @@ tags: [parameters, schema, extension]
 sources:
   - src/pge/parameters/parameter_definitions.py
   - src/pge/parameters/parameter_schema.py
-last_synced_commit: 8c896d8
+last_synced_commit: 4bfc074
 entry_for: [add-parameter]
 ---
 
@@ -21,11 +21,17 @@ Hai un parametro nuovo da accettare a livello stream o sub-blocco YAML (es. nuov
 - Conoscenza schema parametri ([[yaml]] § Parameter Syntax)
 - Bounds del parametro decisi (min, max, default, unità)
 - Decisione: accetta envelope o solo scalare? Se envelope → leggi anche [[make-parameter-envelope-aware]]
+- Se ha un `_range`: la banda è sempre assoluta, o ha senso dichiararla come
+  frazione del valore base? Nel secondo caso lo spec porta anche un
+  `range_unit_path` (es. `grain.duration_range_unit`), e il dominio del range
+  diventa `RELATIVE_RANGE_BOUNDS` invece di quello del parametro. Vale la pena
+  solo dove la base spazia su più ordini di grandezza — vedi [[yaml]] § Banda
+  relativa
 
 ## Passi
 
 1. Aggiungi la definizione (bounds) in `src/pge/parameters/parameter_definitions.py`
-2. Aggiungi la entry di schema in `src/pge/parameters/parameter_schema.py` (`STREAM_PARAMETER_SCHEMA` o sotto-schema appropriato)
+2. Aggiungi la entry di schema in `src/pge/parameters/parameter_schema.py` (`STREAM_PARAMETER_SCHEMA` o sotto-schema appropriato), con `range_path` e — se serve — `range_unit_path`
 3. Accedi al parametro nel `Stream` o controller via `self.parameter_name.evaluate(time)`
 4. Aggiungi test unit per il bound + test di parsing con valore valido e fuori range
 5. Aggiorna [[yaml]] § Tabella Bounds Parametri con la nuova riga

--- a/docs/how-to/add-parameter.md
+++ b/docs/how-to/add-parameter.md
@@ -6,7 +6,7 @@ tags: [parameters, schema, extension]
 sources:
   - src/pge/parameters/parameter_definitions.py
   - src/pge/parameters/parameter_schema.py
-last_synced_commit: 4bfc074
+last_synced_commit: 870bd6f
 entry_for: [add-parameter]
 ---
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -13,7 +13,7 @@ sources:
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
   - src/pge/rendering/numpy_window_registry.py
-last_synced_commit: 870bd6f
+last_synced_commit: e42ed72
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -13,7 +13,7 @@ sources:
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
   - src/pge/rendering/numpy_window_registry.py
-last_synced_commit: fb01d7f
+last_synced_commit: 4bfc074
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -46,7 +46,8 @@ Sezioni rilevanti in questo doc:
   assente = durata del sample
 - [Configurazione Processo (StreamConfig)](#configurazione-processo-streamconfig)
 - [La banda dei `_range`](#la-banda-dei-_range-distribution_mode-e-range_anchor) —
-  larghezza, forma (`distribution_mode`), ancora (`range_anchor`)
+  larghezza, forma (`distribution_mode`), ancora (`range_anchor`), unità
+  (`_range_unit`: assoluta o frazione della base)
 - [Blocco Grain](#blocco-grain), [Pointer](#blocco-pointer), [Pitch](#blocco-pitch), [DeviationProbability](#deviation_probability-variazione-stocastica)
 - [Blocco Voices (Multi-Voice)](#blocco-voices-multi-voice)
 - [Envelopes](#envelopes) — sintassi envelope completa
@@ -196,6 +197,7 @@ Qualsiasi parametro numerico accetta le seguenti forme:
 | Envelope lineare | `density: [[0, 10], [1, 50]]` | Interpolazione lineare tra breakpoint `[time, value]` |
 | Envelope annidata | `density: [[[0, 5], [10, 50]], 1.0, 5]` | Envelope di envelope |
 | Variazione | `grain: {duration: 0.05, duration_range: 0.01}` | banda larga `0.01` (default: `±0.005`) |
+| Variazione relativa | `grain: {duration: 0.05, duration_range: 0.5, duration_range_unit: relative}` | banda larga `0.5 × duration` (default: `±25%`) |
 | Espressione math | `onset: (pi)`, `duration: (10/2)` | Valutato via `safe_eval` |
 | Envelope normalizzato | `step: {points: [[0, 0], [1, 12]], time_mode: normalized}` | `[0, 1]` mappato su `duration` |
 | Envelope per-punto interp | `density: [[0, 5, 'cubic'], [0.5, 30, 'step'], [1, 5]]` | `type` per-segmento, override del default globale (issue #54) |
@@ -338,12 +340,13 @@ clip_margin: 0.0        # tolleranza in secondi per la coda dei grain (default 0
 ### La banda dei `_range`: `distribution_mode` e `range_anchor`
 
 Ogni parametro con un `_range` associato produce, per ogni grano, un valore
-pescato dentro una **banda**. La banda si descrive con tre concetti ortogonali,
-che vanno tenuti distinti:
+pescato dentro una **banda**. La banda si descrive con quattro concetti
+ortogonali, che vanno tenuti distinti:
 
 | concetto | chiave | cosa decide |
 |---|---|---|
 | larghezza | il valore del `_range` stesso | quanto è larga la banda |
+| unità | `<param>_range_unit` | in che cosa quella larghezza è misurata |
 | forma | `distribution_mode` | come la banda viene riempita |
 | ancora | `range_anchor` | dove cade `base` dentro la banda |
 
@@ -392,6 +395,68 @@ invece di lasciare che il safety clamp schiacci la banda contro il tetto. Il
 controllo scatta quando il massimo è calcolabile esattamente (scalare+scalare,
 envelope+scalare, scalare+envelope); con base e range entrambi envelope il
 massimo della somma non è la somma dei massimi, quindi resta il solo clamp.
+
+#### Banda relativa: `<param>_range_unit`
+
+Il `_range` è per default una **quantità assoluta**, nell'unità del parametro:
+`volume_range: 3` sono 3 dB, `duration_range: 0.01` sono 0.01 secondi. Con
+`_range_unit: relative` il numero diventa invece una **frazione del valore
+base**, letta istante per istante — quindi *dopo* l'envelope della base:
+
+```yaml
+grain:
+  duration: [[0, 0.001], [60, 0.5]]   # sweep su tre ordini di grandezza
+  duration_range: 0.5                 # banda larga metà della durata corrente
+  duration_range_unit: relative       # "absolute" (default) | "relative"
+```
+
+| `duration` in quell'istante | banda (`range_anchor: center`) |
+|---|---|
+| 1 ms | 0.75 … 1.25 ms (±25%) |
+| 100 ms | 75 … 125 ms (±25%) |
+| 500 ms | 375 … 625 ms (±25%) |
+
+Serve dove la base spazia su più ordini di grandezza. Con una banda assoluta
+la stessa `duration_range` è molte volte la durata sui grani corti (dove il
+clamp a 1 campione la taglia) e percentualmente trascurabile sui lunghi: lungo
+lo sweep il *carattere* della dispersione cambia da solo, e all'ascolto
+l'effetto dell'asse si confonde con l'effetto collaterale del range. Relativa,
+resta quello che è stato scritto.
+
+**Quale `_range` la ammette.** Oggi solo `grain.duration_range`, via
+`grain.duration_range_unit`. È l'unico parametro la cui base spazia per
+costruzione da 1 campione a 10 secondi; su `volume` (dB) e `pan` (gradi) la
+scala è già logaritmica o ciclica, e una frazione della base non direbbe la
+stessa cosa. Il meccanismo è però dichiarativo (`ParameterSpec.range_unit_path`,
+vedi [[add-parameter]]) e cablarne altri è aggiungere una riga.
+
+Da non confondere con `pointer.offset_range`, che è relativo per costruzione e
+per un altro meccanismo: è già una frazione della finestra di loop attiva, non
+del proprio valore base — che infatti non ha.
+
+**Dominio.** La frazione vive in `[0, 1]`, che è un dominio proprio della
+modalità e non del parametro: 1.0 significa «banda larga quanto la base», e le
+due ancore la consumano in modi diversi.
+
+| `range_anchor` | banda con frazione `r` | massimo a `r = 1` |
+|---|---|---|
+| `center` | `[base·(1 − r/2), base·(1 + r/2)]` | ±50% |
+| `min` | `[base, base·(1 + r)]` | +100% |
+
+Sotto `center` il pavimento della banda non scende mai sotto `base/2`: una
+banda relativa, a differenza di una assoluta, **non può collassare sul minimo
+del parametro**, che è poi la ragione per cui esiste. Sotto `min` vale il
+controllo del tetto descritto sopra, con la formula `base · (1 + range)` al
+posto della somma.
+
+**Cosa non tocca.** Il jitter implicito resta assoluto, per la stessa ragione
+per cui `range_anchor` non lo tocca: non c'è nessuna frazione dichiarata da
+reinterpretare. E proprio perché il jitter prenderebbe il suo posto in
+silenzio, dichiarare `relative` **senza** il `_range` che governa è un
+`MissingFieldError` al parse, non una chiave inerte.
+
+**In partitura** la curva `grain_duration_range` mostra il valore *dichiarato*:
+in modalità relativa è la frazione, non una durata.
 
 > **Cambio di comportamento (post v5.2.0).** Fino alla v5.2.0 `gaussian` leggeva
 > `range` come **σ**, con la campana illimitata richiusa solo dal clamp ai bounds
@@ -517,6 +582,14 @@ grain:
   duration_range: 4.5      # banda larga 4.5 ms (default: ±2.25 ms)
   duration: [[0, 1], [30, 100]]     # envelope: Y in millisecondi
 
+  # Unità della BANDA, indipendente da quella della base: absolute (default)
+  # | relative. Con "relative" duration_range è una frazione di duration,
+  # letta istante per istante — quindi qualunque duration_unit non la tocca,
+  # perché una frazione non ha unità da convertire.
+  duration_range_unit: relative
+  duration: [[0, 0.021], [60, 500]]  # ms, tre ordini di grandezza
+  duration_range: 0.5                # ±25% della durata corrente, sempre
+
   envelope: hanning        # finestra per shape del grano (default: hanning)
   # Vedi sezione "Finestre Disponibili" per tutti i valori validi.
 
@@ -615,6 +688,12 @@ Con qualunque `duration_unit` diverso da `seconds` la `grain.duration` va
 **sempre indicata esplicitamente**: il default `0.05` è in secondi e non
 verrebbe convertito, per cui base (secondi) e `duration_range` (campioni o
 millisecondi) finirebbero in domini diversi. Ometterla → `MissingFieldError`.
+
+`duration_range_unit: relative` toglie il range da quella conversione: una
+frazione è adimensionale, e convertirla la renderebbe muta (`0.5` sotto
+`samples` diventerebbe `0.5/48000`). La `duration` esplicita resta comunque
+obbligatoria — quel vincolo riguarda la base. Vedi
+[Banda relativa](#banda-relativa-param_range_unit).
 `output_sr` è una config globale del motore (48000 Hz), non impostabile
 per-stream nello YAML — per questo `milliseconds`, che non lo usa, dà le stesse
 durate a qualunque frequenza di rendering mentre `samples` no.
@@ -2362,6 +2441,7 @@ un envelope dal YAML al runtime è:
 | `fill_factor` | 0.001 | 50 | 2.0 | priorità su density |
 | `distribution` | 0 | 1 | 0.0 | 0=sync, 1=async |
 | `grain_duration` | 1/48000 (1 campione) | 10 | 0.05 | secondi; `duration_unit` li porta in `samples` o `milliseconds` |
+| `grain_duration_range` | 0 | 1 (assoluto: secondi) / 1 (relativo: frazione) | — | `duration_range_unit: relative` cambia il significato del numero, non il dominio |
 | `volume` | -120 | 12 | 0.0 | dB |
 | `pan` | -3600 | 3600 | 0.0 | gradi |
 | `pitch_ratio` | 0.001 | 8 | 1.0 | ratio diretto |

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -601,7 +601,7 @@ grain:
   # letta istante per istante — quindi qualunque duration_unit non la tocca,
   # perché una frazione non ha unità da convertire.
   duration_range_unit: relative
-  duration: [[0, 0.021], [60, 500]]  # ms, tre ordini di grandezza
+  duration: [[0, 0.021], [60, 500]]  # ms, da un campione a mezzo secondo
   duration_range: 0.5                # ±25% della durata corrente, sempre
 
   envelope: hanning        # finestra per shape del grano (default: hanning)

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -13,7 +13,7 @@ sources:
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
   - src/pge/rendering/numpy_window_registry.py
-last_synced_commit: 5a5d1a9
+last_synced_commit: 870bd6f
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -451,7 +451,11 @@ minimo del parametro, che resta fisso: il pavimento ci finisce sotto appena
 campioni**. Lì il safety clamp riporta al minimo la metà bassa dei draw, con un
 warning per grano; è l'estremo esatto dello sweep da cui l'issue nasce
 (`0.021 ms` è un campione a 48 kHz). Sotto `min` vale invece il controllo del
-tetto descritto sopra, con la formula `base · (1 + range)` al posto della somma.
+tetto descritto sopra, con la formula `base + range · |base|` al posto della
+somma — su una base positiva, cioè `base · (1 + range)`. La larghezza si misura
+sul modulo perché è la stessa che il motore usa a ogni grano: il tetto al parse
+e la banda a runtime sono due letture della stessa banda, e vengono dalla stessa
+funzione.
 
 **Cosa non tocca.** Il jitter implicito resta assoluto, per la stessa ragione
 per cui `range_anchor` non lo tocca: non c'è nessuna frazione dichiarata da
@@ -2451,7 +2455,7 @@ un envelope dal YAML al runtime è:
 | `fill_factor` | 0.001 | 50 | 2.0 | priorità su density |
 | `distribution` | 0 | 1 | 0.0 | 0=sync, 1=async |
 | `grain_duration` | 1/48000 (1 campione) | 10 | 0.05 | secondi; `duration_unit` li porta in `samples` o `milliseconds` |
-| `grain_duration_range` | 0 | 1 (assoluto: secondi) / 1 (relativo: frazione) | — | `duration_range_unit: relative` cambia il significato del numero, non il dominio |
+| `grain_duration_range` | 0 | 1 | — | secondi; con `duration_range_unit: relative` il numero è una frazione e il dominio è quello della modalità (`RELATIVE_RANGE_BOUNDS`), non quello del parametro — che i due `1` coincidano è un caso |
 | `volume` | -120 | 12 | 0.0 | dB |
 | `pan` | -3600 | 3600 | 0.0 | gradi |
 | `pitch_ratio` | 0.001 | 8 | 1.0 | ratio diretto |

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -13,7 +13,7 @@ sources:
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
   - src/pge/rendering/numpy_window_registry.py
-last_synced_commit: 1113c2a
+last_synced_commit: 5a5d1a9
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -443,11 +443,15 @@ due ancore la consumano in modi diversi.
 | `center` | `[base·(1 − r/2), base·(1 + r/2)]` | ±50% |
 | `min` | `[base, base·(1 + r)]` | +100% |
 
-Sotto `center` il pavimento della banda non scende mai sotto `base/2`: una
-banda relativa, a differenza di una assoluta, **non può collassare sul minimo
-del parametro**, che è poi la ragione per cui esiste. Sotto `min` vale il
-controllo del tetto descritto sopra, con la formula `base · (1 + range)` al
-posto della somma.
+Sotto `center` il pavimento della banda è `base·(1 − r/2)`, quindi **si muove
+con la base** invece di restare fermo dove lo mette una banda assoluta: è la
+ragione per cui la modalità esiste. Non è però una garanzia di stare sopra il
+minimo del parametro, che resta fisso: il pavimento ci finisce sotto appena
+`base < min_val / (1 − r/2)` — per `grain_duration`, con `r = 1`, sotto i **2
+campioni**. Lì il safety clamp riporta al minimo la metà bassa dei draw, con un
+warning per grano; è l'estremo esatto dello sweep da cui l'issue nasce
+(`0.021 ms` è un campione a 48 kHz). Sotto `min` vale invece il controllo del
+tetto descritto sopra, con la formula `base · (1 + range)` al posto della somma.
 
 **Cosa non tocca.** Il jitter implicito resta assoluto, per la stessa ragione
 per cui `range_anchor` non lo tocca: non c'è nessuna frazione dichiarata da

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -13,7 +13,7 @@ sources:
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
   - src/pge/rendering/numpy_window_registry.py
-last_synced_commit: 4bfc074
+last_synced_commit: 1113c2a
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -454,6 +454,12 @@ per cui `range_anchor` non lo tocca: non c'è nessuna frazione dichiarata da
 reinterpretare. E proprio perché il jitter prenderebbe il suo posto in
 silenzio, dichiarare `relative` **senza** il `_range` che governa è un
 `MissingFieldError` al parse, non una chiave inerte.
+
+**Assente non è vuota.** Senza la chiave la banda è assoluta, che è il default.
+La chiave scritta e lasciata vuota (`duration_range_unit:`, cioè `null`) è
+invece un `InvalidFieldValueError`: qualcuno l'ha scritta, e leggerla come
+`absolute` non lascerebbe nel file niente da cui accorgersi che quella riga non
+è stata letta. È la stessa regola della chiave gemella `grain.duration_unit`.
 
 **In partitura** la curva `grain_duration_range` mostra il valore *dichiarato*:
 in modalità relativa è la frazione, non una durata.

--- a/src/pge/core/stream.py
+++ b/src/pge/core/stream.py
@@ -510,11 +510,17 @@ class Stream:
         if unit == 'seconds':
             return params
 
-        # Unita' non-secondi: il default seconds (0.05) NON viene scalato. Se
-        # grain.duration non e' esplicito, la base resterebbe in secondi mentre
-        # duration_range e' nell'unita' dichiarata -> due domini diversi nello
-        # stesso blocco. Pretendi una duration esplicita (l'unita' governa base
-        # e range insieme).
+        # Unita' non-secondi: il default seconds (0.05) NON viene scalato, e
+        # quindi una grain.duration implicita resterebbe in secondi mentre chi
+        # ha scritto l'unita' la legge in campioni o millisecondi. Pretendi una
+        # duration esplicita.
+        #
+        # Il vincolo riguarda la BASE, e solo lei. La ragione storica —
+        # «altrimenti base e range finiscono in domini diversi» — copre un ramo
+        # solo da quando il range puo' essere una frazione (issue #267): li' il
+        # range e' adimensionale per costruzione, l'unita' governa la sola base,
+        # e il vincolo resta in piedi lo stesso perche' e' il default in secondi
+        # a non voler dire quel che l'utente intende.
         label = _GRAIN_DURATION_UNIT_LABELS[unit]
         if grain.get('duration') is None:
             err = MissingFieldError(

--- a/src/pge/core/stream.py
+++ b/src/pge/core/stream.py
@@ -152,8 +152,10 @@ class Stream:
         )
         self._init_stream_context(params)
         # === 3.5. UNITA' DI MISURA DURATA GRANO ===
-        # Da qui in poi grain.duration/duration_range sono in secondi,
-        # qualunque sia l'unita' dichiarata nello YAML.
+        # Da qui in poi grain.duration e' in secondi qualunque sia l'unita'
+        # dichiarata nello YAML, e con lei grain.duration_range — tranne dove
+        # quest'ultima e' una frazione della base (grain.duration_range_unit:
+        # relative, issue #267), che adimensionale era e adimensionale resta.
         params = self._pre_normalize_grain_params(params, config.context.output_sr)
         # === 4. PARAMETRI SPECIALI ===
         self._init_grain_reverse(params)

--- a/src/pge/core/stream.py
+++ b/src/pge/core/stream.py
@@ -33,6 +33,7 @@ from pge.shared.exceptions import (
     MissingFieldError,
     SampleNotFoundError,
 )
+from pge.parameters.parameter_definitions import range_unit_is_relative
 from pge.parameters.parameter_schema import STREAM_PARAMETER_SCHEMA
 from pge.parameters.parameter_orchestrator import ParameterOrchestrator
 from pge.parameters.read_direction import (
@@ -471,10 +472,24 @@ class Stream:
         i valori Y; l'asse X resta tempo). Il fattore dipende dall'unita':
         1/output_sr per 'samples', 1e-3 per 'milliseconds'.
 
+        `grain.duration_range_unit: relative` (issue #267) toglie il range da
+        quella conversione: li' il numero non e' una durata ma una FRAZIONE
+        della durata, e una frazione non ha unita' da convertire. Convertirla
+        sarebbe il modo peggiore di sbagliare — `duration_range: 0.5` sotto
+        `duration_unit: samples` diventerebbe 0.5/48000, la variazione
+        sparirebbe, e non ci sarebbe ne' un errore ne' un warning da leggere.
+
         Unico punto del sistema che legge 'duration_unit' dal dizionario
         grezzo: e' un meta-parametro che controlla l'interpretazione degli
-        altri, non un valore sintetizzabile. Il dict originale non viene
-        mutato (cache fingerprint e stream_data_map leggono i dati grezzi).
+        altri, non un valore sintetizzabile. Vale anche per il secondo
+        meta-parametro letto qui, 'duration_range_unit', di cui pero' questo
+        metodo non e' l'unico lettore: la validazione del vocabolario e
+        l'errore per un `relative` senza range stanno nell'orchestratore, che
+        conosce i path YAML e sa nominarli. Qui serve solo sapere se il range
+        va convertito, quindi la lettura e' pura (range_unit_is_relative).
+
+        Il dict originale non viene mutato (cache fingerprint e
+        stream_data_map leggono i dati grezzi).
         """
         grain = params.get('grain')
         if not isinstance(grain, dict) or 'duration_unit' not in grain:
@@ -513,8 +528,13 @@ class Stream:
         factor = (
             1.0 / output_sr if unit == 'samples' else SECONDS_PER_MILLISECOND
         )
+        # Il range entra nella conversione solo se e' una durata; se e' una
+        # frazione della base (issue #267) resta com'e' scritto.
+        keys = ('duration',) if range_unit_is_relative(
+            grain.get('duration_range_unit')) else ('duration', 'duration_range')
+
         scaled_grain = dict(grain)
-        for key in ('duration', 'duration_range'):
+        for key in keys:
             if key in scaled_grain and scaled_grain[key] is not None:
                 scaled_grain[key] = scale_raw_param_values(scaled_grain[key], factor)
 

--- a/src/pge/parameters/parameter.py
+++ b/src/pge/parameters/parameter.py
@@ -64,6 +64,7 @@ class Parameter:
         distribution_mode: str = 'uniform',
         range_anchor: str = ANCHOR_CENTER,
         rng: Optional[random.Random] = None,
+        range_relative: bool = False,
     ):
         self.name = name
         self.owner_id = owner_id
@@ -72,6 +73,13 @@ class Parameter:
         self._bounds = bounds
         self._mod_range = mod_range
         self._probability_gate = NeverGate()
+        # Unita' del range dichiarato (issue #267): False = assoluto (la
+        # larghezza della banda e' il numero scritto), True = relativo (il
+        # numero e' una FRAZIONE del valore base, quindi la banda si misura
+        # solo dopo aver valutato la base a quell'istante). Asse ortogonale
+        # a range_anchor: quella dice dove cade la base dentro la banda,
+        # questa quanto la banda e' larga.
+        self._range_relative = bool(range_relative)
 
         # Ancora effettiva: `range_anchor` vale solo se un range è stato
         # dichiarato. Senza range esplicito si applica il jitter implicito
@@ -117,7 +125,7 @@ class Parameter:
         
         # 1. Valuta il valore base (Base Signal)
         base_val = self._evaluate_input(self._value, time)
-        current_range = self._calculate_range(time)
+        current_range = self._calculate_range(time, base_val)
         # 2. Check Probabilità (Gate)
         # Se il gate è chiuso, restituisci subito il base value (clippato)
         if not self._probability_gate.should_apply(time):
@@ -142,16 +150,35 @@ class Parameter:
         """Helper: Estrae il valore numerico da un numero o da un Envelope."""
         return resolve_param(param, time)
 
-    def _calculate_range(self, time: float) -> float:
-        """Calcola l'ampiezza della variazione."""
+    def _calculate_range(self, time: float, base_val: float = 0.0) -> float:
+        """Calcola l'ampiezza della variazione.
+
+        `base_val` serve solo in modalita' relativa (issue #267), dove la
+        larghezza della banda e' una frazione della base a quell'istante. Ha un
+        default perche' in modalita' assoluta la base non entra nel conto.
+        """
         # Scenario B: Se l'utente non ha messo range, usa il default (Jitter implicito)
+        # Il jitter implicito resta ASSOLUTO anche sotto range_relative: non c'e'
+        # nessuna frazione dichiarata da leggere. Stessa regola di range_anchor,
+        # che sul jitter non agisce per la ragione gemella.
         if self._mod_range is None:
             return self._bounds.default_jitter
         
         val = self._evaluate_input(self._mod_range, time)
         
-        # Limita il range stesso ai bounds di validità definiti per il range
-        return max(self._bounds.min_range, min(self._bounds.max_range, val))
+        # Limita il range stesso ai bounds di validità definiti per il range.
+        # Si clampa la FRAZIONE, non il prodotto: e' la frazione che l'utente ha
+        # scritto ed e' contro il suo dominio che il parser l'ha gia' validata
+        # al parse. Clampare il prodotto farebbe divergere le due letture.
+        val = max(self._bounds.min_range, min(self._bounds.max_range, val))
+
+        if not self._range_relative:
+            return val
+
+        # Una larghezza non ha segno: `abs` copre una base negativa (dominio con
+        # segno, o una cubica che scende sotto i propri breakpoint) senza
+        # trasformare la banda in un valore che AdditiveVariation scarterebbe.
+        return val * abs(base_val)
 
     def _clamp(self, value: float, time: float) -> float:
         """Applica i limiti di sicurezza (Min/Max) e logga se taglia."""
@@ -196,7 +223,11 @@ class Parameter:
 
     @property
     def range_curve(self) -> ParameterCurve:
-        """Come varia nel tempo la deviazione per-grano (absent senza range)."""
+        """Come varia nel tempo la deviazione per-grano (absent senza range).
+
+        E' il valore DICHIARATO, non la banda effettiva: in modalita' relativa
+        (issue #267) e' la frazione, non la larghezza in unita' della base.
+        """
         return ParameterCurve.classify(self._mod_range)
 
     @property

--- a/src/pge/parameters/parameter.py
+++ b/src/pge/parameters/parameter.py
@@ -21,7 +21,10 @@ import random
 from typing import Union, Optional, Callable, Dict
 from pge.envelopes.envelope import Envelope
 from pge.parameters.parameter_curve import ParameterCurve
-from pge.parameters.parameter_definitions import ParameterBounds
+from pge.parameters.parameter_definitions import (
+    ParameterBounds,
+    relative_band_width,
+)
 from pge.shared.logger import log_clip_warning
 from pge.shared.probability_gate import *
 from pge.shared.distribution_strategy import (
@@ -150,12 +153,15 @@ class Parameter:
         """Helper: Estrae il valore numerico da un numero o da un Envelope."""
         return resolve_param(param, time)
 
-    def _calculate_range(self, time: float, base_val: float = 0.0) -> float:
+    def _calculate_range(self, time: float, base_val: float) -> float:
         """Calcola l'ampiezza della variazione.
 
         `base_val` serve solo in modalita' relativa (issue #267), dove la
-        larghezza della banda e' una frazione della base a quell'istante. Ha un
-        default perche' in modalita' assoluta la base non entra nel conto.
+        larghezza della banda e' una frazione della base a quell'istante. E'
+        obbligatorio lo stesso: un default lo renderebbe dimenticabile, e
+        dimenticarlo in modalita' relativa non solleverebbe niente — la banda
+        varrebbe `frazione * 0`, cioe' sparirebbe in silenzio, che e' la
+        stessa forma di difetto muto che la modalita' chiude altrove.
         """
         # Scenario B: Se l'utente non ha messo range, usa il default (Jitter implicito)
         # Il jitter implicito resta ASSOLUTO anche sotto range_relative: non c'e'
@@ -175,10 +181,9 @@ class Parameter:
         if not self._range_relative:
             return val
 
-        # Una larghezza non ha segno: `abs` copre una base negativa (dominio con
-        # segno, o una cubica che scende sotto i propri breakpoint) senza
-        # trasformare la banda in un valore che AdditiveVariation scarterebbe.
-        return val * abs(base_val)
+        # Stessa lettura della banda che il parser usa per il tetto sotto
+        # ancora `min` (relative_band_width): una sola, o le due divergono.
+        return relative_band_width(val, base_val)
 
     def _clamp(self, value: float, time: float) -> float:
         """Applica i limiti di sicurezza (Min/Max) e logga se taglia."""

--- a/src/pge/parameters/parameter_definitions.py
+++ b/src/pge/parameters/parameter_definitions.py
@@ -115,8 +115,10 @@ def range_unit_is_relative(unit) -> bool:
     il path YAML della chiave e sa quindi nominarla nell'errore
     (ParameterOrchestrator); qui una grafia sbagliata legge come non-relativa e
     l'errore arriva comunque, dal punto che sa dirlo bene. Una grafia sola per
-    "e' relativo", condivisa fra il pre-normalizzatore delle unita' dello
-    Stream e l'orchestratore.
+    "e' relativo", condivisa da tutti e tre i lettori: il pre-normalizzatore
+    delle unita' dello Stream, l'orchestratore e il parser — quest'ultimo
+    l'unico a leggerla su un valore gia' validato, e proprio per questo quello
+    dove un confronto scritto a mano sarebbe passato inosservato.
     """
     return unit == RANGE_UNIT_RELATIVE
 

--- a/src/pge/parameters/parameter_definitions.py
+++ b/src/pge/parameters/parameter_definitions.py
@@ -123,6 +123,28 @@ def range_unit_is_relative(unit) -> bool:
     return unit == RANGE_UNIT_RELATIVE
 
 
+def relative_band_width(fraction: float, base: float) -> float:
+    """Larghezza della banda quando il range e' una frazione della base.
+
+    Una larghezza non ha segno: `abs` copre una base negativa (dominio con
+    segno, o una cubica che scende sotto i propri breakpoint) senza
+    trasformare la banda in un valore che AdditiveVariation scarterebbe.
+
+    Una grafia sola, perche' la banda ha due lettori che devono dire la stessa
+    cosa: `Parameter._calculate_range` la misura a ogni grano, e
+    `GranularParser._validate_band_ceiling` la misura una volta al parse per
+    sapere se il tetto sotto ancora `min` ci sta. Scritte separatamente le due
+    letture divergevano gia': il tetto era `base * (1 + range)`, che su una
+    base negativa scende invece di salire, quindi il controllo calcolava un
+    tetto sotto il pavimento della banda vera e passava in silenzio proprio
+    dove doveva parlare — lasciando il safety clamp a dirlo con un warning per
+    grano, cioe' il sintomo che quel controllo esiste per evitare. Su una base
+    non negativa le due formule coincidono (`base + range * base`), che e' il
+    caso dell'unico parametro cablato oggi.
+    """
+    return fraction * abs(base)
+
+
 def relative_range_bounds(bounds: 'ParameterBounds') -> 'ParameterBounds':
     """Gli stessi bounds col dominio del range sostituito da quello frazionario.
 

--- a/src/pge/parameters/parameter_definitions.py
+++ b/src/pge/parameters/parameter_definitions.py
@@ -12,8 +12,10 @@ Qui definiamo COSA sono i parametri, non COME vengono calcolati.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Dict
+
+from pge.shared.exceptions import InvalidFieldValueError
 
 @dataclass(frozen=True)
 class ParameterBounds:
@@ -40,6 +42,97 @@ class ParameterBounds:
     max_range: float = 0.0
     default_jitter: float = 0.0
     variation_mode: str = 'additive'
+
+# =============================================================================
+# UNITA' DEL RANGE DICHIARATO
+# =============================================================================
+# Terzo asse della banda dei `_range`, ortogonale a `distribution_mode` (come
+# la banda si riempie) e a `range_anchor` (dove cade la base dentro la banda):
+# **quanto la banda e' larga**.
+#
+#   absolute (default) -> la larghezza e' il numero scritto, nell'unita' del
+#                         parametro (secondi, dB, gradi)
+#   relative           -> il numero e' una FRAZIONE del valore base a quel
+#                         momento, quindi la larghezza e' `frazione * base`
+#
+# Nasce da issue #267: con `grain.duration` che spazia su piu' ordini di
+# grandezza una banda assoluta e' molte volte la durata sui grani corti e
+# percentualmente trascurabile sui lunghi, e il carattere della dispersione
+# cambia da solo lungo lo sweep. Precedente in casa: `pointer.offset_range` e'
+# gia' relativo, frazione della finestra di loop attiva.
+#
+# Sta qui e non in distribution_strategy.py accanto a RANGE_ANCHORS perche'
+# quello che l'unita' cambia e' il DOMINIO del range — la materia di questo
+# modulo — non il modo in cui la distribuzione lo riempie: chi consuma
+# l'ancora e' la DistributionStrategy, chi consuma l'unita' e' il Parameter,
+# prima che la distribuzione entri in scena.
+
+RANGE_UNIT_ABSOLUTE = 'absolute'
+RANGE_UNIT_RELATIVE = 'relative'
+
+#: Grafie ammesse per una chiave `<param>_range_unit`. La prima e' canonica.
+#: Esposto come registry perche' PGE-ls e PGE-ui lo leggano dal vivo invece di
+#: tenerne una copia statica (stesso ruolo di RANGE_ANCHORS e LOOP_UNITS).
+RANGE_UNITS = (RANGE_UNIT_ABSOLUTE, RANGE_UNIT_RELATIVE)
+
+#: Default: assoluto, cioe' la semantica storica. Chi non scrive la chiave non
+#: vede cambiare niente, e nessun YAML esistente si rilegge diversamente.
+RANGE_UNIT_DEFAULT = RANGE_UNIT_ABSOLUTE
+
+#: Dominio del range dichiarato in modalita' relativa: una frazione in [0, 1].
+#: 1.0 significa una banda larga quanto la base, che le due ancore consumano in
+#: modi diversi — `center` -> [base/2, 3*base/2] (±50%), `min` -> [base, 2*base]
+#: (+100%). E' un dominio proprio della modalita', non del parametro: che per
+#: `grain_duration` coincida col max_range assoluto (1.0 s) e' una coincidenza
+#: numerica, e alzare l'uno non deve alzare l'altro.
+RELATIVE_RANGE_BOUNDS = (0.0, 1.0)
+
+
+def validate_range_unit(unit, field: str = 'range_unit') -> str:
+    """Valida una grafia di `<param>_range_unit`, restituendola normalizzata.
+
+    Args:
+        unit: la grafia scritta nel YAML.
+        field: il path YAML della chiave, per nominarla nell'errore. Il
+            chiamante lo conosce (`spec.range_unit_path`), questo modulo no.
+
+    Raises:
+        InvalidFieldValueError: se la grafia non e' fra RANGE_UNITS.
+    """
+    if unit not in RANGE_UNITS:
+        raise InvalidFieldValueError(
+            field=field,
+            value=unit,
+            hint=f"valori ammessi: {' | '.join(RANGE_UNITS)}",
+        )
+    return unit
+
+
+def range_unit_is_relative(unit) -> bool:
+    """True se la grafia dichiara una banda relativa.
+
+    Lettura PURA: non valida il vocabolario. La validazione tocca a chi conosce
+    il path YAML della chiave e sa quindi nominarla nell'errore
+    (ParameterOrchestrator); qui una grafia sbagliata legge come non-relativa e
+    l'errore arriva comunque, dal punto che sa dirlo bene. Una grafia sola per
+    "e' relativo", condivisa fra il pre-normalizzatore delle unita' dello
+    Stream e l'orchestratore.
+    """
+    return unit == RANGE_UNIT_RELATIVE
+
+
+def relative_range_bounds(bounds: 'ParameterBounds') -> 'ParameterBounds':
+    """Gli stessi bounds col dominio del range sostituito da quello frazionario.
+
+    Sostituisce, non restringe: il dominio assoluto e quello relativo misurano
+    grandezze diverse, e un `min` fra i due non vorrebbe dire niente.
+    """
+    return replace(
+        bounds,
+        min_range=RELATIVE_RANGE_BOUNDS[0],
+        max_range=RELATIVE_RANGE_BOUNDS[1],
+    )
+
 
 # =============================================================================
 # SYSTEM CONSTANTS & DEFAULTS

--- a/src/pge/parameters/parameter_orchestrator.py
+++ b/src/pge/parameters/parameter_orchestrator.py
@@ -19,10 +19,15 @@ from pge.parameters.parser import GranularParser
 from pge.shared.probability_gate import ProbabilityGate
 from pge.parameters.parameter import Parameter
 from pge.parameters.parameter_schema import ParameterSpec, resolve_yaml_path
-from pge.parameters.parameter_definitions import DEFAULT_PROB
+from pge.parameters.parameter_definitions import (
+    DEFAULT_PROB,
+    RANGE_UNIT_DEFAULT,
+    range_unit_is_relative,
+    validate_range_unit,
+)
 from pge.parameters.exclusive_selector import ExclusiveGroupSelector
 from pge.core.stream_config import StreamConfig
-from pge.shared.exceptions import ConfigError
+from pge.shared.exceptions import ConfigError, MissingFieldError
 from pge.shared.seeding import component_rng
 
 class ParameterOrchestrator:
@@ -93,7 +98,55 @@ class ParameterOrchestrator:
             name=spec.name,  # Stessa chiave per bounds e attributo
             value_raw=value,
             range_raw=range_val,
+            range_unit=self._range_unit_from_spec(spec, yaml_data, range_val),
         )
+
+    def _range_unit_from_spec(
+        self,
+        spec: ParameterSpec,
+        yaml_data: dict,
+        range_val: Any,
+    ) -> str:
+        """L'unita' del `_range` dichiarata nello YAML (issue #267).
+
+        Qui e non nel parser perche' qui si conoscono i due path YAML: quello
+        dell'unita', per nominare la chiave in un errore di vocabolario, e
+        quello del range, per nominare la chiave che manca. Il parser conosce
+        solo il nome del parametro (`grain_duration`), che non e' come si
+        scrive nel file.
+
+        Un `relative` senza il range che governa e' un errore, non una chiave
+        inerte: senza range dichiarato scatta il jitter implicito, che e'
+        assoluto — cioe' esattamente cio' che l'utente stava cercando di
+        evitare. Stessa regola di `grain.duration_unit`, che pretende una
+        `grain.duration` esplicita per non lasciare base e range in due domini
+        diversi.
+        """
+        if not spec.range_unit_path:
+            return RANGE_UNIT_DEFAULT
+
+        raw = resolve_yaml_path(yaml_data, spec.range_unit_path, None)
+        if raw is None:
+            return RANGE_UNIT_DEFAULT
+
+        try:
+            unit = validate_range_unit(raw, field=spec.range_unit_path)
+        except ConfigError as err:
+            err.stream_id = self._config.context.stream_id
+            raise
+
+        if range_unit_is_relative(unit) and range_val is None:
+            err = MissingFieldError(
+                field=spec.range_path,
+                hint=(f"con {spec.range_unit_path}: {unit} la banda va "
+                      "dichiarata esplicitamente come frazione del valore "
+                      "base (senza, varrebbe il jitter implicito, che e' "
+                      "assoluto)."),
+            )
+            err.stream_id = self._config.context.stream_id
+            raise err
+
+        return unit
 
     def create_parameter_with_gate(
         self,

--- a/src/pge/parameters/parameter_orchestrator.py
+++ b/src/pge/parameters/parameter_orchestrator.py
@@ -30,6 +30,15 @@ from pge.core.stream_config import StreamConfig
 from pge.shared.exceptions import ConfigError, MissingFieldError
 from pge.shared.seeding import component_rng
 
+#: Sentinella per "la chiave non c'e'", distinta da una chiave scritta e
+#: lasciata vuota (`duration_range_unit:` -> None nello YAML). Serve perche'
+#: `resolve_yaml_path` restituisce il default in entrambi i casi, e i due casi
+#: non vogliono dire la stessa cosa: assente e' nessuna richiesta, vuota e' una
+#: riga che qualcuno ha scritto e che nessuno legge. Vedi
+#: `_range_unit_from_spec`.
+_KEY_ABSENT = object()
+
+
 class ParameterOrchestrator:
     """
     Orchestratore: collega GranularParser e GateFactory senza accoppiarli.
@@ -121,12 +130,22 @@ class ParameterOrchestrator:
         evitare. Stessa regola di `grain.duration_unit`, che pretende una
         `grain.duration` esplicita per non lasciare base e range in due domini
         diversi.
+
+        Per la stessa ragione la chiave **assente** e la chiave **vuota** non
+        prendono la stessa strada. Assente vuol dire che nessuno ha chiesto
+        niente, e il default assoluto e' la risposta giusta. Vuota
+        (`duration_range_unit:`, cioe' `None`) vuol dire che qualcuno l'ha
+        scritta: leggerla come `absolute` sarebbe il default piu' muto
+        possibile — nel file non resta niente da cui accorgersi che la riga non
+        e' stata letta. La gemella `grain.duration_unit` una grafia vuota la
+        rifiuta gia'; qui la distinzione ha bisogno di una sentinella, perche'
+        `resolve_yaml_path` non ha modo di dire assente da nullo.
         """
         if not spec.range_unit_path:
             return RANGE_UNIT_DEFAULT
 
-        raw = resolve_yaml_path(yaml_data, spec.range_unit_path, None)
-        if raw is None:
+        raw = resolve_yaml_path(yaml_data, spec.range_unit_path, _KEY_ABSENT)
+        if raw is _KEY_ABSENT:
             return RANGE_UNIT_DEFAULT
 
         try:

--- a/src/pge/parameters/parameter_schema.py
+++ b/src/pge/parameters/parameter_schema.py
@@ -29,6 +29,11 @@ class ParameterSpec:
         yaml_path: Percorso nel YAML (supporta dot notation: 'grain.duration')
         default: Valore di default se assente nel YAML
         range_path: Percorso YAML per il parametro _range associato (opzionale)
+        range_unit_path: Percorso YAML della chiave che dichiara l'UNITA' del
+            _range (issue #267): 'absolute' (default, la larghezza e' il numero
+            scritto) o 'relative' (il numero e' una frazione del valore base).
+            Ha senso solo insieme a range_path. Opzionale: senza, il range e'
+            assoluto e la chiave non esiste per quel parametro.
         deviation_probability_key: Chiave nel blocco deviation_probability (opzionale)
         is_smart: Se True, crea un oggetto Parameter. Se False, valore raw.
     
@@ -39,6 +44,7 @@ class ParameterSpec:
     yaml_path: str
     default: Any
     range_path: Optional[str] = None
+    range_unit_path: Optional[str] = None
     deviation_probability_key: Optional[str] = None
     is_smart: bool = True
     exclusive_group: Optional[str] = None
@@ -85,6 +91,14 @@ STREAM_PARAMETER_SCHEMA: List[ParameterSpec] = [
         yaml_path='grain.duration',
         default=0.05,
         range_path='grain.duration_range',
+        # Unico parametro con la banda relativa (issue #267): e' l'unico la cui
+        # base spazia per costruzione su piu' ordini di grandezza — da 1
+        # campione a 10 secondi — e su cui quindi una banda assoluta cambia
+        # carattere da sola lungo un envelope. Su volume (dB), pan (gradi) e
+        # pitch la scala e' gia' logaritmica o ciclica: una frazione della base
+        # li' non direbbe la stessa cosa. Il meccanismo pero' e' dichiarativo:
+        # cablarne un altro e' aggiungere questa riga.
+        range_unit_path='grain.duration_range_unit',
         deviation_probability_key='duration'
     ),
     ParameterSpec(

--- a/src/pge/parameters/parser.py
+++ b/src/pge/parameters/parser.py
@@ -223,9 +223,13 @@ class GranularParser:
     def _validated_range_unit(self, unit: Any) -> str:
         """Valida l'unita' del range attribuendo l'errore allo stream.
 
-        `None` significa "chiave non dichiarata" e vale il default assoluto: e'
+        `None` significa "unita' non dichiarata" e vale il default assoluto: e'
         il caso di ogni parametro che l'unita' non la prevede nemmeno, quindi
-        non puo' essere un errore.
+        qui non puo' essere un errore. Qui il parser riceve un *valore*, non
+        una chiave, e non ha modo di distinguere una chiave assente da una
+        scritta e lasciata vuota: quella distinzione la fa
+        `ParameterOrchestrator._range_unit_from_spec`, che lo YAML lo legge, e
+        una chiave vuota la rifiuta prima di arrivare fin qui.
 
         Il chiamante ordinario (ParameterOrchestrator) valida gia' la grafia
         col path YAML della chiave, e li' l'errore la nomina per esteso. Questo

--- a/src/pge/parameters/parser.py
+++ b/src/pge/parameters/parser.py
@@ -15,7 +15,13 @@ from __future__ import annotations
 from typing import Union, Optional, List, Any
 from pge.parameters.parameter import Parameter, ParamInput
 from pge.envelopes.envelope import Envelope, create_scaled_envelope
-from pge.parameters.parameter_definitions import get_parameter_definition
+from pge.parameters.parameter_definitions import (
+    RANGE_UNIT_DEFAULT,
+    RANGE_UNIT_RELATIVE,
+    get_parameter_definition,
+    relative_range_bounds,
+    validate_range_unit,
+)
 from pge.shared.distribution_strategy import (
     ANCHOR_CENTER,
     ANCHOR_MIN,
@@ -76,7 +82,8 @@ class GranularParser:
         value_raw: Any,
         range_raw: Any = None,
         prob_raw: Any = None,
-        bounds_override: Any = None
+        bounds_override: Any = None,
+        range_unit: Any = None,
     ) -> Parameter:
         """
         Metodo Factory principale. Crea un oggetto Parameter pronto all'uso.
@@ -89,6 +96,9 @@ class GranularParser:
             bounds_override: ParameterBounds espliciti. Se forniti, bypassano il
                 Registry — usati per parametri con bounds dinamici (es. pitch,
                 i cui bounds derivano dall'unità di misura, non dal nome).
+            range_unit: unità del `_range` dichiarato (issue #267): 'absolute'
+                (default, la larghezza è il numero scritto) o 'relative' (il
+                numero è una frazione del valore base). None → default.
 
         Returns:
             Un'istanza configurata di Parameter.
@@ -100,6 +110,14 @@ class GranularParser:
                   else get_parameter_definition(name,
                                                 sample_dur_sec=self.sample_dur_sec,
                                                 output_sr=self.output_sr))
+
+        # 1-bis. Unita' del range (issue #267). La sostituzione del dominio si
+        # applica DOPO i bounds, override compreso: e' un fatto della modalita',
+        # non del parametro, e vale su qualunque provenienza dei bounds.
+        unit = self._validated_range_unit(range_unit)
+        is_relative = unit == RANGE_UNIT_RELATIVE
+        if is_relative:
+            bounds = relative_range_bounds(bounds)
 
         # 2. Converte i dati grezzi in formati utilizzabili (float o Envelope)
         # Qui avviene la normalizzazione temporale se necessaria
@@ -135,7 +153,8 @@ class GranularParser:
         ) if clean_prob is not None else None
 
         # 3-bis. Tetto della banda sotto ancora `min` (vedi _validate_band_ceiling).
-        self._validate_band_ceiling(validated_value, validated_range, bounds, name)
+        self._validate_band_ceiling(validated_value, validated_range, bounds, name,
+                                    is_relative=is_relative)
 
         # 4. Assembla e restituisce l'oggetto Smart Parameter.
         # RNG per-componente (issue #154): ogni parametro pesca dal proprio
@@ -152,6 +171,7 @@ class GranularParser:
             distribution_mode=self.distribution_mode,
             range_anchor=self.range_anchor,
             rng=component_rng(self.seed, self.rng_id, name),
+            range_relative=is_relative,
         )
 
     # =========================================================================
@@ -200,14 +220,43 @@ class GranularParser:
             err.stream_id = self.stream_id
             raise
 
+    def _validated_range_unit(self, unit: Any) -> str:
+        """Valida l'unita' del range attribuendo l'errore allo stream.
+
+        `None` significa "chiave non dichiarata" e vale il default assoluto: e'
+        il caso di ogni parametro che l'unita' non la prevede nemmeno, quindi
+        non puo' essere un errore.
+
+        Il chiamante ordinario (ParameterOrchestrator) valida gia' la grafia
+        col path YAML della chiave, e li' l'errore la nomina per esteso. Questo
+        e' il presidio del parser per chi lo usa direttamente: gemello di
+        _validated_anchor, e per la stessa ragione — qui si conosce lo
+        stream_id, che il modulo dei bounds non conosce.
+        """
+        if unit is None:
+            return RANGE_UNIT_DEFAULT
+        try:
+            return validate_range_unit(unit)
+        except InvalidFieldValueError as err:
+            err.stream_id = self.stream_id
+            raise
+
     def _validate_band_ceiling(
         self,
         value: Optional[ParamInput],
         mod_range: Optional[ParamInput],
         bounds: Any,
         param_name: str,
+        is_relative: bool = False,
     ) -> None:
-        """Verifica che la banda `[base, base + range]` stia sotto max_val.
+        """Verifica che il tetto della banda stia sotto max_val.
+
+        Il tetto dipende dall'unita' del range (issue #267): `base + range`
+        quando il range e' assoluto, `base * (1 + range)` quando e' una
+        frazione. Sommare una frazione a una durata sommerebbe due grandezze
+        diverse, e il controllo lascerebbe passare in silenzio proprio le bande
+        larghe — con `base: 8` e frazione `0.5` la somma da' 8.5, il prodotto
+        12.
 
         Si applica SOLO con `range_anchor: min`. Sotto l'ancora `center` la
         banda arriva a `base + range/2` e resta gestita dal safety clamp a
@@ -222,17 +271,18 @@ class GranularParser:
         Solo il tetto: il pavimento della banda e' `base`, gia' validato
         contro min_val da _validate_and_clip.
 
-        Il controllo scatta solo quando il massimo della somma e' calcolabile
-        da un solo lato:
+        Il controllo scatta solo quando il massimo e' calcolabile da un solo
+        lato:
 
-            base scalare + range scalare   -> base + range
-            base envelope + range scalare  -> max(base) + range
-            base scalare + range envelope  -> base + max(range)
+            base scalare + range scalare   -> base, range
+            base envelope + range scalare  -> max(base), range
+            base scalare + range envelope  -> base, max(range)
 
-        Con entrambi envelope il massimo della somma non e' la somma dei
-        massimi (i due picchi possono cadere in istanti diversi): il controllo
-        sarebbe conservativo e un falso positivo bloccherebbe un render valido.
-        In quel caso resta il safety clamp.
+        Con entrambi envelope il massimo della combinazione non e' la
+        combinazione dei massimi (i due picchi possono cadere in istanti
+        diversi): il controllo sarebbe conservativo e un falso positivo
+        bloccherebbe un render valido. In quel caso resta il safety clamp.
+        Vale per la somma come per il prodotto.
 
         Il picco di un envelope e' stimato dai suoi breakpoint. Con
         interpolazione cubica la curva puo' superare i breakpoint, quindi la
@@ -254,14 +304,21 @@ class GranularParser:
                       if value_is_env else float(value))
         peak_range = (max(y for _, y in mod_range.breakpoints)
                       if range_is_env else float(mod_range))
-        ceiling = peak_value + peak_range
+        # Il prodotto dei picchi e' il picco del prodotto solo perche' entrambi
+        # i fattori sono non negativi: il range e' gia' validato contro
+        # min_range >= 0, e questo controllo ha senso solo dove il tetto e'
+        # sopra lo zero. Sotto un dominio con segno andrebbe riscritto — ma li'
+        # una banda relativa non avrebbe comunque significato.
+        ceiling = (peak_value * (1.0 + peak_range) if is_relative
+                   else peak_value + peak_range)
 
         if ceiling <= bounds.max_val:
             return
 
+        formula = ('base * (1 + range)' if is_relative else 'base + range')
         err = ParameterBoundError(
             param_name=param_name,
-            value_type='base + range (range_anchor: min)',
+            value_type=f'{formula} (range_anchor: min)',
             value=ceiling,
             min_bound=bounds.min_val,
             max_bound=bounds.max_val,

--- a/src/pge/parameters/parser.py
+++ b/src/pge/parameters/parser.py
@@ -17,8 +17,8 @@ from pge.parameters.parameter import Parameter, ParamInput
 from pge.envelopes.envelope import Envelope, create_scaled_envelope
 from pge.parameters.parameter_definitions import (
     RANGE_UNIT_DEFAULT,
-    RANGE_UNIT_RELATIVE,
     get_parameter_definition,
+    range_unit_is_relative,
     relative_range_bounds,
     validate_range_unit,
 )
@@ -115,7 +115,7 @@ class GranularParser:
         # applica DOPO i bounds, override compreso: e' un fatto della modalita',
         # non del parametro, e vale su qualunque provenienza dei bounds.
         unit = self._validated_range_unit(range_unit)
-        is_relative = unit == RANGE_UNIT_RELATIVE
+        is_relative = range_unit_is_relative(unit)
         if is_relative:
             bounds = relative_range_bounds(bounds)
 

--- a/src/pge/parameters/parser.py
+++ b/src/pge/parameters/parser.py
@@ -286,7 +286,7 @@ class GranularParser:
         lato:
 
             base scalare + range scalare   -> base, range
-            base envelope + range scalare  -> max(base), range
+            base envelope + range scalare  -> ogni base, range
             base scalare + range envelope  -> base, max(range)
 
         Con entrambi envelope il massimo della combinazione non e' la
@@ -294,6 +294,11 @@ class GranularParser:
         diversi): il controllo sarebbe conservativo e un falso positivo
         bloccherebbe un render valido. In quel caso resta il safety clamp.
         Vale per la somma come per il prodotto.
+
+        Sulla base si valuta ogni breakpoint e non il solo massimo: la banda
+        relativa e' monotona nella base solo finche' la frazione sta sotto 1,
+        e farne un'assunzione legherebbe questo controllo al tetto di
+        RELATIVE_RANGE_BOUNDS senza dirlo (vedi il commento al calcolo).
 
         Il picco di un envelope e' stimato dai suoi breakpoint. Con
         interpolazione cubica la curva puo' superare i breakpoint, quindi la
@@ -311,18 +316,26 @@ class GranularParser:
         if value_is_env and range_is_env:
             return
 
-        peak_value = (max(y for _, y in value.breakpoints)
-                      if value_is_env else float(value))
+        # La combinazione e' monotona nel RANGE — la larghezza non e' mai
+        # negativa (min_range >= 0) e cresce con la frazione — quindi il suo
+        # picco basta. Nella BASE no, e assumerlo era una dipendenza
+        # nascosta: sotto zero la banda relativa vale `base * (1 - r)`, che
+        # cresce con la base solo finche' `r <= 1` e decresce appena `r` lo
+        # supera. Reggeva percio' su RELATIVE_RANGE_BOUNDS[1] <= 1 — un
+        # dominio che nessuno dichiara load-bearing e che allargare sarebbe
+        # retrocompatibile ovunque tranne qui. Valutare la banda su OGNI base
+        # candidata invece che sul solo picco toglie l'assunzione: costa un
+        # max su breakpoint gia' letti, e il tetto resta quello di prima dove
+        # la base e' positiva, cioe' sull'unico parametro cablato oggi.
+        base_candidates = ([y for _, y in value.breakpoints]
+                           if value_is_env else [float(value)])
         peak_range = (max(y for _, y in mod_range.breakpoints)
                       if range_is_env else float(mod_range))
-        # Il picco della banda e' il picco della base piu' la larghezza
-        # misurata sul picco della base: la larghezza cresce con |base| e il
-        # range e' gia' validato contro min_range >= 0, quindi la
-        # combinazione e' monotona nei due picchi e valutarla sui massimi da'
-        # il massimo. Vale anche su una base negativa, dove la banda sale
-        # dalla base invece di scendere.
-        ceiling = (peak_value + relative_band_width(peak_range, peak_value)
-                   if is_relative else peak_value + peak_range)
+        ceiling = max(
+            base + (relative_band_width(peak_range, base)
+                    if is_relative else peak_range)
+            for base in base_candidates
+        )
 
         if ceiling <= bounds.max_val:
             return

--- a/src/pge/parameters/parser.py
+++ b/src/pge/parameters/parser.py
@@ -19,6 +19,7 @@ from pge.parameters.parameter_definitions import (
     RANGE_UNIT_DEFAULT,
     get_parameter_definition,
     range_unit_is_relative,
+    relative_band_width,
     relative_range_bounds,
     validate_range_unit,
 )
@@ -256,11 +257,17 @@ class GranularParser:
         """Verifica che il tetto della banda stia sotto max_val.
 
         Il tetto dipende dall'unita' del range (issue #267): `base + range`
-        quando il range e' assoluto, `base * (1 + range)` quando e' una
+        quando il range e' assoluto, `base + range * |base|` quando e' una
         frazione. Sommare una frazione a una durata sommerebbe due grandezze
         diverse, e il controllo lascerebbe passare in silenzio proprio le bande
-        larghe — con `base: 8` e frazione `0.5` la somma da' 8.5, il prodotto
-        12.
+        larghe — con `base: 8` e frazione `0.5` la somma da' 8.5, la banda
+        arriva a 12.
+
+        La larghezza della banda relativa non si riscrive qui: la misura
+        `relative_band_width`, la stessa funzione che `Parameter` chiama a ogni
+        grano. Il tetto al parse e la banda a runtime sono due letture della
+        stessa banda, e devono coincidere per costruzione — scritte
+        separatamente divergevano gia' su una base negativa.
 
         Si applica SOLO con `range_anchor: min`. Sotto l'ancora `center` la
         banda arriva a `base + range/2` e resta gestita dal safety clamp a
@@ -308,18 +315,19 @@ class GranularParser:
                       if value_is_env else float(value))
         peak_range = (max(y for _, y in mod_range.breakpoints)
                       if range_is_env else float(mod_range))
-        # Il prodotto dei picchi e' il picco del prodotto solo perche' entrambi
-        # i fattori sono non negativi: il range e' gia' validato contro
-        # min_range >= 0, e questo controllo ha senso solo dove il tetto e'
-        # sopra lo zero. Sotto un dominio con segno andrebbe riscritto — ma li'
-        # una banda relativa non avrebbe comunque significato.
-        ceiling = (peak_value * (1.0 + peak_range) if is_relative
-                   else peak_value + peak_range)
+        # Il picco della banda e' il picco della base piu' la larghezza
+        # misurata sul picco della base: la larghezza cresce con |base| e il
+        # range e' gia' validato contro min_range >= 0, quindi la
+        # combinazione e' monotona nei due picchi e valutarla sui massimi da'
+        # il massimo. Vale anche su una base negativa, dove la banda sale
+        # dalla base invece di scendere.
+        ceiling = (peak_value + relative_band_width(peak_range, peak_value)
+                   if is_relative else peak_value + peak_range)
 
         if ceiling <= bounds.max_val:
             return
 
-        formula = ('base * (1 + range)' if is_relative else 'base + range')
+        formula = ('base + range * |base|' if is_relative else 'base + range')
         err = ParameterBoundError(
             param_name=param_name,
             value_type=f'{formula} (range_anchor: min)',

--- a/tests/core/test_grain_duration_range_relative.py
+++ b/tests/core/test_grain_duration_range_relative.py
@@ -1,0 +1,150 @@
+"""
+test_grain_duration_range_relative.py
+
+`grain.duration_range_unit: relative` visto dai grani generati (issue #267).
+
+La banda diventa una frazione della durata nominale a quell'istante, quindi la
+dispersione mantiene lo stesso carattere lungo tutto un envelope che spazia su
+piu' ordini di grandezza — il caso da cui l'issue nasce: `grain.duration` da 1
+campione a 500 ms.
+
+Coperta qui anche l'interazione con `duration_unit`, che e' il punto in cui la
+feature poteva rompersi in silenzio: una frazione e' adimensionale e non va
+convertita in secondi insieme alla base. Convertita, `duration_range: 0.5` sotto
+`duration_unit: samples` diventerebbe 0.5/48000 e la variazione sparirebbe
+senza un errore, senza un warning, senza niente da leggere nel file.
+"""
+
+import statistics
+
+import pytest
+from unittest.mock import patch
+
+from pge.core.stream import Stream
+from pge.shared.constants import DEFAULT_OUTPUT_SR
+from pge.shared.exceptions import InvalidFieldValueError, MissingFieldError
+from conftest import flat_grains
+
+
+SAMPLE_DUR = 10.0
+
+
+def _make_stream(grain_block, **extra):
+    params = {
+        'stream_id': 's1',
+        'onset': 0.0,
+        'duration': 1.0,
+        'sample': 'test.wav',
+        'density': 200,
+        'grain': grain_block,
+        'deviation_probability': {'duration': 100},
+    }
+    params.update(extra)
+    with patch('pge.core.stream.get_sample_duration', return_value=SAMPLE_DUR):
+        stream = Stream(params, seed=42)
+    stream.sample_table_num = 1
+    stream.window_table_map = {'hanning': 2}
+    return stream
+
+
+class TestBandaRelativaSuiGrani:
+
+    def test_la_dispersione_e_una_frazione_della_durata(self):
+        s = _make_stream({
+            'duration': 0.1,
+            'duration_range': 0.5,
+            'duration_range_unit': 'relative',
+        })
+        durate = [g.duration for g in flat_grains(s)]
+
+        assert len(durate) > 50
+        assert min(durate) >= 0.075 - 1e-9
+        assert max(durate) <= 0.125 + 1e-9
+
+    def test_lungo_un_envelope_il_carattere_della_dispersione_resta(self):
+        """Il punto dell'issue, misurato: la dispersione relativa e' costante.
+
+        Con una banda assoluta lo stesso sweep darebbe una deviazione enorme in
+        proporzione sui grani corti e trascurabile sui lunghi.
+        """
+        s = _make_stream({
+            'duration': [[0.0, 0.002], [1.0, 0.5]],
+            'duration_range': 0.4,
+            'duration_range_unit': 'relative',
+        })
+        grani = flat_grains(s)
+        assert len(grani) > 100
+
+        meta = len(grani) // 2
+        nominale = lambda g: s.grain_duration.value.evaluate(g.onset - s.onset)
+        scarto = lambda g: abs(g.duration - nominale(g)) / nominale(g)
+
+        prima = statistics.mean(scarto(g) for g in grani[:meta])
+        dopo = statistics.mean(scarto(g) for g in grani[meta:])
+
+        # stessa dispersione RELATIVA sulle due meta' dello sweep, malgrado le
+        # durate nominali differiscano di due ordini di grandezza
+        assert prima == pytest.approx(dopo, abs=0.05)
+        assert 0.05 < prima < 0.25   # ~0.1 = media di |uniforme(-0.2, 0.2)|
+
+
+class TestConvivenzaConDurationUnit:
+    """Una frazione e' adimensionale: `duration_unit` non la tocca."""
+
+    def test_samples_converte_la_base_ma_non_la_frazione(self):
+        s = _make_stream({
+            'duration': 4800,
+            'duration_unit': 'samples',
+            'duration_range': 0.5,
+            'duration_range_unit': 'relative',
+        })
+        durate = [g.duration for g in flat_grains(s)]
+        nominale = 4800 / DEFAULT_OUTPUT_SR
+
+        assert min(durate) >= nominale * 0.75 - 1e-9
+        assert max(durate) <= nominale * 1.25 + 1e-9
+        # la banda e' larga: senza la guardia varrebbe 0.5/48000 e sarebbe muta
+        assert max(durate) - min(durate) > nominale * 0.3
+
+    def test_milliseconds_converte_la_base_ma_non_la_frazione(self):
+        s = _make_stream({
+            'duration': 100,
+            'duration_unit': 'milliseconds',
+            'duration_range': 0.5,
+            'duration_range_unit': 'relative',
+        })
+        durate = [g.duration for g in flat_grains(s)]
+
+        assert min(durate) >= 0.075 - 1e-9
+        assert max(durate) <= 0.125 + 1e-9
+        assert max(durate) - min(durate) > 0.03
+
+    def test_in_assoluto_la_frazione_non_esiste_e_si_converte_tutto(self):
+        """Controprova: senza `relative`, `duration_range` e' in campioni."""
+        s = _make_stream({
+            'duration': 4800,
+            'duration_unit': 'samples',
+            'duration_range': 480,
+        })
+        durate = [g.duration for g in flat_grains(s)]
+        nominale = 4800 / DEFAULT_OUTPUT_SR
+        meta_banda = 240 / DEFAULT_OUTPUT_SR
+
+        assert min(durate) >= nominale - meta_banda - 1e-9
+        assert max(durate) <= nominale + meta_banda + 1e-9
+
+
+class TestErroriDalloStream:
+
+    def test_grafia_ignota(self):
+        with pytest.raises(InvalidFieldValueError) as exc:
+            _make_stream({'duration': 0.1, 'duration_range': 0.5,
+                          'duration_range_unit': 'percentuale'})
+
+        assert 'grain.duration_range_unit' in str(exc.value)
+
+    def test_relative_senza_range(self):
+        with pytest.raises(MissingFieldError) as exc:
+            _make_stream({'duration': 0.1, 'duration_range_unit': 'relative'})
+
+        assert 'grain.duration_range' in str(exc.value)

--- a/tests/core/test_grain_duration_range_relative.py
+++ b/tests/core/test_grain_duration_range_relative.py
@@ -156,3 +156,57 @@ class TestErroriDalloStream:
             _make_stream({'duration': 0.1, 'duration_range_unit': 'relative'})
 
         assert 'grain.duration_range' in str(exc.value)
+
+
+class TestIlPavimentoDellaBanda:
+    """Fin dove la banda relativa tiene il pavimento sopra il minimo.
+
+    La proprieta' per cui la modalita' esiste e' che il pavimento della banda
+    e' `base * (1 - r/2)`, quindi si muove con la base invece di restare fermo:
+    su un grano corto una banda assoluta lo trascina sotto il minimo del
+    parametro, una relativa lo tiene proporzionale.
+
+    Proporzionale non vuol dire pero' «sopra il minimo in ogni caso»: il
+    minimo di `grain_duration` e' un campione, quindi `base * (1 - r/2)` ci
+    finisce sotto appena `base < 1 campione / (1 - r/2)` — a `r = 1`, sotto i
+    2 campioni. E' l'estremo esatto dello sweep dell'issue (`0.021 ms` = un
+    campione), quindi la condizione va misurata, non promessa: quello che
+    resta e' il safety clamp, un warning per grano.
+    """
+
+    _UN_CAMPIONE = 1.0 / DEFAULT_OUTPUT_SR
+
+    def _durate(self, campioni, frazione):
+        s = _make_stream({
+            'duration': campioni,
+            'duration_unit': 'samples',
+            'duration_range': frazione,
+            'duration_range_unit': 'relative',
+        })
+        return [g.duration for g in flat_grains(s)]
+
+    def test_sopra_la_soglia_il_pavimento_e_quello_della_frazione(self):
+        """4 campioni con `r = 1`: il pavimento e' 2 campioni, nessun clamp."""
+        durate = self._durate(4, 1.0)
+
+        assert min(durate) > self._UN_CAMPIONE * 1.5
+        assert min(durate) >= self._UN_CAMPIONE * 2 - 1e-12
+        assert max(durate) <= self._UN_CAMPIONE * 6 + 1e-12
+
+    def test_sotto_la_soglia_il_clamp_taglia_meta_banda(self):
+        """1 campione con `r = 1`: il pavimento sarebbe mezzo campione.
+
+        Non essendoci mezzi campioni, il clamp lo riporta a uno e una buona
+        meta' dei grani ci si accumula sopra. La banda relativa attenua il
+        problema della banda assoluta, non lo cancella — ed e' il motivo per
+        cui `yaml.md` lo dichiara con la sua condizione invece che in assoluto.
+        """
+        durate = self._durate(1, 1.0)
+        sul_minimo = sum(1 for d in durate
+                         if abs(d - self._UN_CAMPIONE) < 1e-15)
+
+        assert min(durate) == pytest.approx(self._UN_CAMPIONE)
+        assert sul_minimo > len(durate) * 0.25
+        # ...e la banda sopravvive comunque: non e' collassata TUTTA sul minimo,
+        # che e' invece quel che fa una banda assoluta su un grano di 1 campione.
+        assert max(durate) > self._UN_CAMPIONE * 1.2

--- a/tests/core/test_grain_duration_range_relative.py
+++ b/tests/core/test_grain_duration_range_relative.py
@@ -143,6 +143,14 @@ class TestErroriDalloStream:
 
         assert 'grain.duration_range_unit' in str(exc.value)
 
+    def test_grafia_vuota(self):
+        """La chiave c'e' e non dice niente: non e' il default assoluto."""
+        with pytest.raises(InvalidFieldValueError) as exc:
+            _make_stream({'duration': 0.1, 'duration_range': 0.5,
+                          'duration_range_unit': None})
+
+        assert 'grain.duration_range_unit' in str(exc.value)
+
     def test_relative_senza_range(self):
         with pytest.raises(MissingFieldError) as exc:
             _make_stream({'duration': 0.1, 'duration_range_unit': 'relative'})

--- a/tests/parameters/test_grain_duration_range_unit.py
+++ b/tests/parameters/test_grain_duration_range_unit.py
@@ -1,0 +1,146 @@
+# tests/parameters/test_grain_duration_range_unit.py
+"""
+test_grain_duration_range_unit.py
+
+La chiave YAML `grain.duration_range_unit` (issue #267), dallo schema fino al
+Parameter costruito.
+
+Catena: ParameterSpec.range_unit_path -> ParameterOrchestrator -> GranularParser
+-> Parameter(range_relative=...).
+
+Il meccanismo e' dichiarativo e generico (qualunque spec puo' dichiarare un
+`range_unit_path`); oggi l'unico cablato e' `grain_duration`, che e' il
+parametro per cui l'issue nasce — su volume, pan e pitch una banda relativa non
+avrebbe lo stesso senso musicale, e resta assoluta finche' non la si chiede.
+"""
+
+import pytest
+
+from pge.core.stream_config import StreamConfig, StreamContext
+from pge.parameters.parameter_definitions import (
+    RANGE_UNIT_RELATIVE,
+    RELATIVE_RANGE_BOUNDS,
+)
+from pge.parameters.parameter_orchestrator import ParameterOrchestrator
+from pge.parameters.parameter_schema import (
+    STREAM_PARAMETER_SCHEMA,
+    get_parameter_spec,
+)
+from pge.shared.exceptions import InvalidFieldValueError, MissingFieldError
+from pge.shared.probability_gate import AlwaysGate
+
+
+def _orchestrator():
+    ctx = StreamContext(stream_id='s1', onset=0.0, duration=10.0,
+                        sample='x.wav', sample_dur_sec=5.0)
+    return ParameterOrchestrator(StreamConfig(context=ctx))
+
+
+def _grain_duration(grain: dict):
+    spec = get_parameter_spec('grain_duration')
+    return _orchestrator().create_parameter_with_gate({'grain': grain}, spec)
+
+
+class TestSchema:
+
+    def test_grain_duration_dichiara_il_path_dell_unita(self):
+        assert get_parameter_spec('grain_duration').range_unit_path == (
+            'grain.duration_range_unit')
+
+    def test_nessun_altro_parametro_lo_dichiara_oggi(self):
+        con_unita = [s.name for s in STREAM_PARAMETER_SCHEMA if s.range_unit_path]
+
+        assert con_unita == ['grain_duration']
+
+    def test_uno_spec_senza_range_non_puo_avere_un_unita(self):
+        """Un'unita' senza il range che governa non vuol dire niente."""
+        for spec in STREAM_PARAMETER_SCHEMA:
+            if spec.range_unit_path:
+                assert spec.range_path, spec.name
+
+
+class TestCablaggioDalloYaml:
+
+    def test_senza_la_chiave_la_banda_resta_assoluta(self):
+        p = _grain_duration({'duration': 0.5, 'duration_range': 0.5})
+        p.set_probability_gate(AlwaysGate())
+
+        draws = [p.get_value(0.0) for _ in range(300)]
+
+        assert min(draws) >= 0.25 - 1e-9
+        assert max(draws) <= 0.75 + 1e-9
+
+    def test_con_relative_la_banda_e_una_frazione(self):
+        p = _grain_duration({
+            'duration': 0.5,
+            'duration_range': 0.5,
+            'duration_range_unit': RANGE_UNIT_RELATIVE,
+        })
+        p.set_probability_gate(AlwaysGate())
+
+        draws = [p.get_value(0.0) for _ in range(300)]
+
+        # banda = 0.5 * 0.5 = 0.25 centrata su 0.5
+        assert min(draws) >= 0.375 - 1e-9
+        assert max(draws) <= 0.625 + 1e-9
+
+    def test_absolute_esplicito_e_il_comportamento_storico(self):
+        p = _grain_duration({
+            'duration': 0.5,
+            'duration_range': 0.5,
+            'duration_range_unit': 'absolute',
+        })
+        p.set_probability_gate(AlwaysGate())
+
+        assert max(p.get_value(0.0) for _ in range(300)) <= 0.75 + 1e-9
+
+    def test_una_grafia_ignota_nomina_la_chiave_per_esteso(self):
+        with pytest.raises(InvalidFieldValueError) as exc:
+            _grain_duration({
+                'duration': 0.5,
+                'duration_range': 0.5,
+                'duration_range_unit': 'percentuale',
+            })
+
+        assert 'grain.duration_range_unit' in str(exc.value)
+        assert exc.value.stream_id == 's1'
+
+
+class TestUnitaSenzaRange:
+    """`duration_range_unit: relative` senza `duration_range` e' la stessa
+    trappola di `duration_unit: samples` senza `duration`: chi la scrive crede
+    di aver attivato la banda relativa e invece prende il jitter implicito, che
+    e' assoluto (0.01 s) — cioe' esattamente la patologia dell'issue sui grani
+    da un campione. Meglio dirlo una volta, prima di renderizzare."""
+
+    def test_relative_pretende_il_range(self):
+        with pytest.raises(MissingFieldError) as exc:
+            _grain_duration({'duration': 0.5,
+                             'duration_range_unit': RANGE_UNIT_RELATIVE})
+
+        assert 'grain.duration_range' in str(exc.value)
+        assert exc.value.stream_id == 's1'
+
+    def test_un_range_a_zero_e_una_dichiarazione(self):
+        """Zero e' una banda degenere ma dichiarata: nessun errore."""
+        p = _grain_duration({'duration': 0.5, 'duration_range': 0,
+                             'duration_range_unit': RANGE_UNIT_RELATIVE})
+
+        assert p.has_explicit_range is True
+
+    def test_absolute_senza_range_non_pretende_niente(self):
+        """`absolute` e' il default: dichiararlo non cambia nulla."""
+        p = _grain_duration({'duration': 0.5, 'duration_range_unit': 'absolute'})
+
+        assert p.has_explicit_range is False
+
+
+class TestDominio:
+
+    def test_la_frazione_e_validata_contro_il_dominio_relativo(self):
+        from pge.shared.exceptions import ParameterBoundError
+
+        oltre = RELATIVE_RANGE_BOUNDS[1] + 0.5
+        with pytest.raises(ParameterBoundError):
+            _grain_duration({'duration': 0.5, 'duration_range': oltre,
+                             'duration_range_unit': RANGE_UNIT_RELATIVE})

--- a/tests/parameters/test_grain_duration_range_unit.py
+++ b/tests/parameters/test_grain_duration_range_unit.py
@@ -106,6 +106,34 @@ class TestCablaggioDalloYaml:
         assert exc.value.stream_id == 's1'
 
 
+class TestChiaveVuota:
+    """`duration_range_unit:` scritta e lasciata vuota (nello YAML: `None`).
+
+    Non e' la chiave assente. Assente vuol dire che nessuno ha chiesto niente;
+    vuota vuol dire che qualcuno l'ha scritta e nessuno la legge — e nel file
+    non resta niente da cui accorgersene, che e' il modo piu' muto di
+    sbagliare. E' la stessa ragione per cui `relative` senza `duration_range`
+    e' un errore invece di una chiave inerte, ed e' gia' la regola della
+    gemella `grain.duration_unit`, che una grafia vuota la rifiuta.
+    """
+
+    def test_la_chiave_vuota_non_e_un_default_silenzioso(self):
+        with pytest.raises(InvalidFieldValueError) as exc:
+            _grain_duration({'duration': 0.5, 'duration_range': 0.5,
+                             'duration_range_unit': None})
+
+        assert 'grain.duration_range_unit' in str(exc.value)
+        assert exc.value.stream_id == 's1'
+
+    def test_la_chiave_assente_resta_il_default(self):
+        """Il default vale per chi non ha scritto la chiave, non per chi
+        l'ha scritta a vuoto: le due strade restano distinte."""
+        p = _grain_duration({'duration': 0.5, 'duration_range': 0.5})
+        p.set_probability_gate(AlwaysGate())
+
+        assert max(p.get_value(0.0) for _ in range(300)) <= 0.75 + 1e-9
+
+
 class TestUnitaSenzaRange:
     """`duration_range_unit: relative` senza `duration_range` e' la stessa
     trappola di `duration_unit: samples` senza `duration`: chi la scrive crede

--- a/tests/parameters/test_parameter_range_unit.py
+++ b/tests/parameters/test_parameter_range_unit.py
@@ -140,6 +140,30 @@ class TestJitterImplicito:
         assert max(draws) <= 11.0 + 1e-9
 
 
+class TestLaBaseNonHaDefault:
+    """`_calculate_range` pretende la base, non la assume zero.
+
+    In modalita' assoluta la base non entra nel conto, quindi un default
+    sarebbe innocuo li' — ed e' esattamente per questo che sarebbe pericoloso:
+    un chiamante che lo dimentica non vedrebbe niente finche' qualcuno non
+    dichiara `relative`, dove la banda varrebbe `frazione * 0`, cioe'
+    sparirebbe senza un'eccezione, senza un warning e senza niente da leggere
+    nel file. La stessa forma di difetto muto che la modalita' chiude altrove
+    (`duration_unit` che convertiva la frazione).
+    """
+
+    def test_la_firma_non_permette_di_dimenticarla(self):
+        p = _param(10.0, 0.5, relative=True)
+
+        with pytest.raises(TypeError):
+            p._calculate_range(0.0)
+
+    def test_con_la_base_risponde_la_larghezza_della_banda(self):
+        p = _param(10.0, 0.5, relative=True)
+
+        assert p._calculate_range(0.0, 10.0) == pytest.approx(5.0)
+
+
 class TestBaseConSegno:
     """La LARGHEZZA della banda non ha segno, la base si'.
 

--- a/tests/parameters/test_parameter_range_unit.py
+++ b/tests/parameters/test_parameter_range_unit.py
@@ -138,3 +138,49 @@ class TestJitterImplicito:
 
         assert min(draws) >= 9.0 - 1e-9
         assert max(draws) <= 11.0 + 1e-9
+
+
+class TestBaseConSegno:
+    """La LARGHEZZA della banda non ha segno, la base si'.
+
+    `grain_duration` vive sopra lo zero, ma il meccanismo non e' suo: il parser
+    accetta `range_unit` su qualunque parametro, e i domini con segno esistono
+    gia' (`volume` in dB, da -120 a +12). Li' la frazione va letta sul MODULO
+    della base, o la larghezza esce negativa.
+
+    E una larghezza negativa non e' un errore rumoroso: `UniformDistribution`
+    con `spread <= 0` restituisce il centro, quindi la variazione sparirebbe
+    senza un'eccezione, senza un warning e senza niente nel file da cui
+    accorgersene — lo stesso difetto muto che la modalita' relativa chiude
+    altrove (`duration_unit` che convertiva la frazione).
+    """
+
+    _DB = dict(min_val=-120.0, max_val=12.0)
+
+    def test_su_base_negativa_la_banda_e_larga_quanto_il_modulo(self):
+        """-6 dB con frazione 0.5 -> banda larga 3 dB, cioe' -7.5 .. -4.5."""
+        p = _param(-6.0, 0.5, relative=True, bounds=_bounds(**self._DB))
+
+        draws = [p.get_value(0.0) for _ in range(N)]
+
+        assert min(draws) >= -7.5 - 1e-9
+        assert max(draws) <= -4.5 + 1e-9
+        # Il punto: la banda esiste ed e' a cavallo della base. Col segno
+        # sbagliato tutti i draw sarebbero esattamente -6.0.
+        assert min(draws) < -6.0 < max(draws)
+
+    def test_su_base_negativa_l_ancora_min_sale_comunque(self):
+        """`min` parte dalla base e sale: -6 dB con frazione 0.5 -> -6 .. -3.
+
+        Con la larghezza negativa la banda non salirebbe affatto: `min` e'
+        l'ancora dove il segno della larghezza si vede meglio, perche' li' la
+        banda e' tutta da una parte sola.
+        """
+        p = _param(-6.0, 0.5, relative=True, anchor=ANCHOR_MIN,
+                   bounds=_bounds(**self._DB))
+
+        draws = [p.get_value(0.0) for _ in range(N)]
+
+        assert min(draws) >= -6.0 - 1e-9
+        assert max(draws) <= -3.0 + 1e-9
+        assert max(draws) > -6.0

--- a/tests/parameters/test_parameter_range_unit.py
+++ b/tests/parameters/test_parameter_range_unit.py
@@ -1,0 +1,140 @@
+# tests/parameters/test_parameter_range_unit.py
+"""
+test_parameter_range_unit.py
+
+`duration_range_unit: relative` (issue #267): la larghezza della banda smette
+di essere una quantita' assoluta e diventa una FRAZIONE del valore base, letta
+istante per istante — quindi dopo l'envelope della base.
+
+Catena: YAML grain -> ParameterSpec.range_unit_path -> ParameterOrchestrator
+-> GranularParser -> Parameter(range_relative=True).
+
+La ragione sta nell'issue: con `grain.duration` che spazia su piu' ordini di
+grandezza (1 campione -> 500 ms) una banda assoluta cambia carattere da sola
+lungo lo sweep — enorme sui grani corti, trascurabile sui lunghi. Relativa,
+il carattere della dispersione resta costante.
+"""
+
+import random
+
+import pytest
+
+from pge.envelopes.envelope import Envelope
+from pge.parameters.parameter import Parameter
+from pge.parameters.parameter_definitions import ParameterBounds
+from pge.shared.distribution_strategy import ANCHOR_CENTER, ANCHOR_MIN
+from pge.shared.probability_gate import AlwaysGate
+
+
+N = 400
+
+
+def _bounds(**kw):
+    defaults = dict(
+        min_val=0.0, max_val=1000.0,
+        min_range=0.0, max_range=1.0,
+        default_jitter=0.0, variation_mode='additive',
+    )
+    defaults.update(kw)
+    return ParameterBounds(**defaults)
+
+
+def _param(value, mod_range, relative, anchor=ANCHOR_CENTER, bounds=None):
+    p = Parameter(
+        name='grain_duration',
+        value=value,
+        bounds=bounds if bounds is not None else _bounds(),
+        mod_range=mod_range,
+        distribution_mode='uniform',
+        range_anchor=anchor,
+        rng=random.Random(20260910),
+        range_relative=relative,
+    )
+    p.set_probability_gate(AlwaysGate())
+    return p
+
+
+class TestBandaRelativaScalare:
+
+    def test_ancora_center_banda_e_frazione_del_valore(self):
+        """base 10, frazione 0.5 -> banda larga 5, cioe' 7.5 .. 12.5."""
+        p = _param(10.0, 0.5, relative=True)
+
+        draws = [p.get_value(0.0) for _ in range(N)]
+
+        assert min(draws) >= 7.5 - 1e-9
+        assert max(draws) <= 12.5 + 1e-9
+        # la banda viene davvero riempita: non e' un range collassato a zero
+        assert max(draws) - min(draws) > 4.0
+
+    def test_stessa_frazione_su_base_diversa_da_banda_diversa(self):
+        """E' il punto dell'issue: la frazione segue la base."""
+        piccolo = _param(1.0, 0.5, relative=True)
+        grande = _param(100.0, 0.5, relative=True)
+
+        assert min(piccolo.get_value(0.0) for _ in range(N)) >= 0.75 - 1e-9
+        assert max(piccolo.get_value(0.0) for _ in range(N)) <= 1.25 + 1e-9
+        assert min(grande.get_value(0.0) for _ in range(N)) >= 75.0 - 1e-9
+        assert max(grande.get_value(0.0) for _ in range(N)) <= 125.0 + 1e-9
+
+    def test_assoluto_resta_il_comportamento_storico(self):
+        """Senza dichiarare nulla la banda e' larga quanto il numero scritto."""
+        p = _param(10.0, 0.5, relative=False)
+
+        draws = [p.get_value(0.0) for _ in range(N)]
+
+        assert min(draws) >= 9.75 - 1e-9
+        assert max(draws) <= 10.25 + 1e-9
+
+
+class TestBandaRelativaNelTempo:
+
+    def test_la_frazione_si_applica_alla_base_di_quell_istante(self):
+        """La base e' un envelope: la banda si allarga con lei."""
+        base = Envelope([[0.0, 1.0], [10.0, 100.0]])
+        p = _param(base, 0.5, relative=True)
+
+        inizio = [p.get_value(0.0) for _ in range(N)]
+        fine = [p.get_value(10.0) for _ in range(N)]
+
+        assert max(inizio) <= 1.25 + 1e-9
+        assert min(fine) >= 75.0 - 1e-9
+
+    def test_anche_la_frazione_puo_essere_un_envelope(self):
+        """Entrambi envelope: la banda e' il prodotto istante per istante."""
+        base = Envelope([[0.0, 10.0], [10.0, 10.0]])
+        frazione = Envelope([[0.0, 0.0], [10.0, 1.0]])
+        p = _param(base, frazione, relative=True)
+
+        assert p.get_value(0.0) == pytest.approx(10.0)
+        fine = [p.get_value(10.0) for _ in range(N)]
+        assert min(fine) >= 5.0 - 1e-9
+        assert max(fine) <= 15.0 + 1e-9
+
+
+class TestBandaRelativaEAncora:
+
+    def test_ancora_min_sale_dalla_base(self):
+        """`min`: banda [base, base * (1 + frazione)]."""
+        p = _param(10.0, 1.0, relative=True, anchor=ANCHOR_MIN)
+
+        draws = [p.get_value(0.0) for _ in range(N)]
+
+        assert min(draws) >= 10.0 - 1e-9
+        assert max(draws) <= 20.0 + 1e-9
+
+
+class TestJitterImplicito:
+
+    def test_resta_assoluto_anche_in_modalita_relativa(self):
+        """Senza `_range` dichiarato non c'e' nessuna frazione da leggere.
+
+        Stessa regola di `range_anchor`: il jitter implicito non e' una banda
+        dichiarata, e' un tremolio attorno al valore.
+        """
+        p = _param(10.0, None, relative=True, bounds=_bounds(default_jitter=2.0))
+
+        draws = [p.get_value(0.0) for _ in range(N)]
+
+        assert min(draws) >= 9.0 - 1e-9
+        assert max(draws) <= 11.0 + 1e-9

--- a/tests/parameters/test_parameter_schema.py
+++ b/tests/parameters/test_parameter_schema.py
@@ -239,13 +239,13 @@ class TestParameterSpecFieldDefinition:
     """Verifica che la struttura del dataclass sia corretta."""
 
     def test_field_count(self):
-        """ParameterSpec ha esattamente 8 campi."""
-        assert len(fields(ParameterSpec)) == 8
+        """ParameterSpec ha esattamente 9 campi."""
+        assert len(fields(ParameterSpec)) == 9
 
     def test_field_names(self):
         """I nomi dei campi sono quelli attesi."""
         expected = {
-            'name', 'yaml_path', 'default', 'range_path',
+            'name', 'yaml_path', 'default', 'range_path', 'range_unit_path',
             'deviation_probability_key', 'is_smart', 'exclusive_group', 'group_priority'
         }
         actual = {f.name for f in fields(ParameterSpec)}

--- a/tests/parameters/test_range_unit_definitions.py
+++ b/tests/parameters/test_range_unit_definitions.py
@@ -465,3 +465,103 @@ class TestUnaSolaGrafiaDelPredicato:
         assert len(compare) == 1
         assert any(isinstance(l, ast.Name) and l.id == 'RANGE_UNIT_RELATIVE'
                    for l in [compare[0].left, *compare[0].comparators])
+
+
+# =============================================================================
+# IL TETTO NON ASSUME LA MONOTONIA DELLA BANDA NELLA BASE
+# =============================================================================
+
+class TestIlTettoNonAssumeLaMonotonia:
+    """Il tetto al parse si misura su OGNI base candidata, non sul suo picco.
+
+    `_validate_band_ceiling` valuta la banda in un punto solo — il picco della
+    base — e questo da' il massimo solo se `f(base) = base + r*|base|` cresce
+    con la base. Sopra lo zero e' sempre vero; sotto lo zero `f` vale
+    `base*(1 - r)`, che cresce con la base finche' `r <= 1` e **decresce**
+    appena `r` supera 1. Il commento accanto al calcolo giustificava il passo
+    con `min_range >= 0`, che e' il bound sbagliato: quello rende la larghezza
+    non negativa (monotonia nella *frazione*), non la combinazione monotona
+    nella base.
+
+    L'invariante che regge davvero il passo e' quindi `RELATIVE_RANGE_BOUNDS[1]
+    <= 1` — che nessuna riga dichiarava load-bearing, e che la descrizione
+    della PR annuncia anzi come allargabile «senza rompere niente» (allargare
+    un dominio e' retrocompatibile). Allargato a 2.0, il controllo tornava a
+    calcolare un tetto sotto la banda vera e a tacere proprio dove esiste per
+    parlare: il difetto che il giro di review precedente ha chiuso, rientrato
+    da un'altra porta.
+
+    Qui il puntello si toglie apposta — e' l'unico modo di misurare una
+    dipendenza nascosta — e il tetto deve reggere lo stesso.
+    """
+
+    _DOMINIO_LARGO = 2.0
+    _BASE_NEGATIVA = [[0, -8.0], [4, -3.0]]   # picco -3, ma |base| max su -8
+
+    def _parser(self, anchor='min'):
+        from pge.core.stream_config import StreamConfig, StreamContext
+        from pge.parameters.parser import GranularParser
+
+        ctx = StreamContext(stream_id='s1', onset=0.0, duration=4.0,
+                            sample='x.wav', sample_dur_sec=10.0)
+        return GranularParser(StreamConfig(context=ctx, range_anchor=anchor))
+
+    def _allarga_il_dominio(self, monkeypatch):
+        from pge.parameters import parameter_definitions
+
+        monkeypatch.setattr(parameter_definitions, 'RELATIVE_RANGE_BOUNDS',
+                            (0.0, self._DOMINIO_LARGO))
+
+    def test_su_base_envelope_negativa_il_tetto_e_il_massimo_vero(self, monkeypatch):
+        """Frazione 2.0 su base [-8, -3]: la banda arriva a 8, non a 3.
+
+        `f(-8) = -8 + 2*8 = 8`, `f(-3) = -3 + 2*3 = 3`. Valutando sul solo
+        picco della base il controllo legge 3, lo trova sotto `max_val: 5` e
+        tace; a runtime il clamp taglia a 5 con un warning per grano — il
+        sintomo che questo controllo esiste per evitare.
+        """
+        from pge.parameters.parameter_definitions import ParameterBounds
+        from pge.shared.exceptions import ParameterBoundError
+
+        self._allarga_il_dominio(monkeypatch)
+        bounds = ParameterBounds(min_val=-10.0, max_val=5.0,
+                                 min_range=0.0, max_range=self._DOMINIO_LARGO)
+
+        with pytest.raises(ParameterBoundError) as exc:
+            self._parser().parse_parameter(
+                'volume', self._BASE_NEGATIVA, self._DOMINIO_LARGO,
+                bounds_override=bounds, range_unit=RANGE_UNIT_RELATIVE)
+
+        assert '8' in exc.value.user_message()
+
+    def test_una_banda_che_ci_sta_passa_e_i_draw_la_rispettano(self, monkeypatch):
+        """L'altra meta': alzato `max_val` a 10 il parse passa, e nessun draw
+        supera il tetto che aveva promesso — senza clamp di mezzo."""
+        from pge.parameters.parameter_definitions import ParameterBounds
+        from pge.shared.probability_gate import AlwaysGate
+
+        self._allarga_il_dominio(monkeypatch)
+        bounds = ParameterBounds(min_val=-10.0, max_val=10.0,
+                                 min_range=0.0, max_range=self._DOMINIO_LARGO)
+
+        p = self._parser().parse_parameter(
+            'volume', self._BASE_NEGATIVA, self._DOMINIO_LARGO,
+            bounds_override=bounds, range_unit=RANGE_UNIT_RELATIVE)
+        p.set_probability_gate(AlwaysGate())
+
+        draws = [p.get_value(t * 4.0 / 20) for t in range(21) for _ in range(30)]
+
+        assert max(draws) <= 8.0 + 1e-9
+        assert max(draws) > 5.0           # la banda ci arriva davvero
+
+    def test_sul_dominio_odierno_la_risposta_non_cambia(self):
+        """Regressione: con `r <= 1` valutare su ogni base o sul solo picco
+        da' lo stesso numero, ed e' il numero di prima."""
+        from pge.shared.exceptions import ParameterBoundError
+
+        with pytest.raises(ParameterBoundError) as exc:
+            self._parser().parse_parameter(
+                'grain_duration', [[0, 1.0], [4, 8.0]], 0.5,
+                range_unit=RANGE_UNIT_RELATIVE)
+
+        assert '12' in exc.value.user_message()

--- a/tests/parameters/test_range_unit_definitions.py
+++ b/tests/parameters/test_range_unit_definitions.py
@@ -1,0 +1,84 @@
+# tests/parameters/test_range_unit_definitions.py
+"""
+test_range_unit_definitions.py
+
+Il vocabolario di `duration_range_unit` e il dominio della frazione (#267).
+
+Un range relativo NON ha lo stesso dominio di uno assoluto: assoluto e' una
+quantita' nell'unita' del parametro (secondi, dB, gradi), relativo e' una
+frazione adimensionale. Che per `grain_duration` i due numeri coincidano oggi
+(max_range 1.0 in entrambi) e' un caso, non un progetto — e i test qui sotto lo
+misurano su un parametro dove i due domini divergono davvero.
+"""
+
+import pytest
+
+from pge.parameters.parameter_definitions import (
+    GRANULAR_PARAMETERS,
+    RANGE_UNITS,
+    RANGE_UNIT_ABSOLUTE,
+    RANGE_UNIT_DEFAULT,
+    RANGE_UNIT_RELATIVE,
+    RELATIVE_RANGE_BOUNDS,
+    get_parameter_definition,
+    range_unit_is_relative,
+    relative_range_bounds,
+    validate_range_unit,
+)
+from pge.shared.exceptions import InvalidFieldValueError
+
+
+class TestVocabolario:
+
+    def test_le_due_grafie_ammesse(self):
+        assert RANGE_UNITS == (RANGE_UNIT_ABSOLUTE, RANGE_UNIT_RELATIVE)
+
+    def test_il_default_e_assoluto(self):
+        """Retrocompatibilita': chi non scrive la chiave non cambia semantica."""
+        assert RANGE_UNIT_DEFAULT == RANGE_UNIT_ABSOLUTE
+
+    def test_una_grafia_valida_torna_normalizzata(self):
+        assert validate_range_unit('relative') == RANGE_UNIT_RELATIVE
+
+    def test_una_grafia_ignota_e_un_errore_di_campo(self):
+        with pytest.raises(InvalidFieldValueError) as exc:
+            validate_range_unit('relativo', field='grain.duration_range_unit')
+
+        assert 'grain.duration_range_unit' in str(exc.value)
+
+    def test_il_predicato_riconosce_solo_la_grafia_relativa(self):
+        assert range_unit_is_relative(RANGE_UNIT_RELATIVE) is True
+        assert range_unit_is_relative(RANGE_UNIT_ABSOLUTE) is False
+        assert range_unit_is_relative(None) is False
+
+
+class TestDominioDellaFrazione:
+
+    def test_la_frazione_vive_in_zero_uno(self):
+        """1.0 = ±50% con ancora `center`, +100% con ancora `min`."""
+        assert RELATIVE_RANGE_BOUNDS == (0.0, 1.0)
+
+    def test_sostituisce_il_dominio_assoluto_del_parametro(self):
+        """Su `volume` i due domini divergono: 24 dB contro la frazione."""
+        assoluto = GRANULAR_PARAMETERS['volume']
+        relativo = relative_range_bounds(assoluto)
+
+        assert assoluto.max_range == 24.0
+        assert (relativo.min_range, relativo.max_range) == RELATIVE_RANGE_BOUNDS
+
+    def test_non_tocca_nient_altro_dei_bounds(self):
+        assoluto = GRANULAR_PARAMETERS['volume']
+        relativo = relative_range_bounds(assoluto)
+
+        assert relativo.min_val == assoluto.min_val
+        assert relativo.max_val == assoluto.max_val
+        assert relativo.default_jitter == assoluto.default_jitter
+        assert relativo.variation_mode == assoluto.variation_mode
+
+    def test_convive_col_minimo_dinamico_di_grain_duration(self):
+        """Il pavimento di 1 campione non deve sparire sotto la sostituzione."""
+        dinamico = get_parameter_definition('grain_duration', output_sr=48000)
+        relativo = relative_range_bounds(dinamico)
+
+        assert relativo.min_val == pytest.approx(1.0 / 48000)
+        assert (relativo.min_range, relativo.max_range) == RELATIVE_RANGE_BOUNDS

--- a/tests/parameters/test_range_unit_definitions.py
+++ b/tests/parameters/test_range_unit_definitions.py
@@ -82,3 +82,113 @@ class TestDominioDellaFrazione:
 
         assert relativo.min_val == pytest.approx(1.0 / 48000)
         assert (relativo.min_range, relativo.max_range) == RELATIVE_RANGE_BOUNDS
+
+
+# =============================================================================
+# PARSER: dall'unita' al Parameter
+# =============================================================================
+
+class TestParserRangeUnit:
+    """`GranularParser.parse_parameter(range_unit=...)` cabla i due effetti:
+    il dominio contro cui la frazione e' validata, e la modalita' del
+    Parameter costruito."""
+
+    def _parser(self, **cfg):
+        from pge.core.stream_config import StreamConfig, StreamContext
+        from pge.parameters.parser import GranularParser
+
+        ctx = StreamContext(stream_id='s1', onset=0.0, duration=4.0,
+                            sample='x.wav', sample_dur_sec=10.0)
+        return GranularParser(StreamConfig(context=ctx, **cfg))
+
+    def test_senza_unita_resta_assoluto(self):
+        p = self._parser().parse_parameter('grain_duration', 0.05, 0.01)
+
+        assert p.get_value(0.0) == pytest.approx(0.05, abs=0.005)
+
+    def test_relativo_produce_una_banda_frazionaria(self):
+        from pge.shared.probability_gate import AlwaysGate
+
+        p = self._parser().parse_parameter(
+            'grain_duration', 0.5, 0.5, range_unit=RANGE_UNIT_RELATIVE)
+        p.set_probability_gate(AlwaysGate())
+
+        draws = [p.get_value(0.0) for _ in range(400)]
+
+        # banda = 0.5 * 0.5 = 0.25, centrata su 0.5 -> 0.375 .. 0.625
+        assert min(draws) >= 0.375 - 1e-9
+        assert max(draws) <= 0.625 + 1e-9
+        assert max(draws) - min(draws) > 0.2
+
+    def test_una_frazione_fuori_dominio_e_un_errore_di_bounds(self):
+        from pge.shared.exceptions import ParameterBoundError
+
+        with pytest.raises(ParameterBoundError):
+            self._parser().parse_parameter(
+                'grain_duration', 0.05, 1.5, range_unit=RANGE_UNIT_RELATIVE)
+
+    def test_il_dominio_relativo_non_e_quello_del_parametro(self):
+        """`volume` ammette 24 dB assoluti ma solo 1.0 di frazione."""
+        from pge.shared.exceptions import ParameterBoundError
+
+        self._parser().parse_parameter('volume', 0.0, 12.0)   # assoluto: passa
+
+        with pytest.raises(ParameterBoundError):
+            self._parser().parse_parameter(
+                'volume', 0.0, 12.0, range_unit=RANGE_UNIT_RELATIVE)
+
+    def test_una_grafia_ignota_arriva_attribuita_allo_stream(self):
+        with pytest.raises(InvalidFieldValueError) as exc:
+            self._parser().parse_parameter(
+                'grain_duration', 0.05, 0.5, range_unit='relativo')
+
+        assert exc.value.stream_id == 's1'
+
+
+# =============================================================================
+# TETTO DELLA BANDA (range_anchor: min)
+# =============================================================================
+
+class TestTettoDellaBandaRelativa:
+    """Con ancora `min` la banda arriva a `base * (1 + frazione)`, non a
+    `base + frazione`: sommare una frazione a una durata sarebbe sommare due
+    grandezze diverse, e il controllo al parse lascerebbe passare bande che
+    poi il safety clamp schiaccia contro il tetto, un warning per grano."""
+
+    def _parser(self, anchor):
+        from pge.core.stream_config import StreamConfig, StreamContext
+        from pge.parameters.parser import GranularParser
+
+        ctx = StreamContext(stream_id='s1', onset=0.0, duration=4.0,
+                            sample='x.wav', sample_dur_sec=10.0)
+        return GranularParser(StreamConfig(context=ctx, range_anchor=anchor))
+
+    def test_una_banda_che_sfora_il_massimo_e_un_errore(self):
+        """8 s con frazione 0.5 arriva a 12 s: oltre il tetto di 10 s.
+
+        La somma 8 + 0.5 non ci arriverebbe mai — e' il caso che il controllo
+        additivo lascerebbe passare in silenzio."""
+        from pge.shared.exceptions import ParameterBoundError
+
+        with pytest.raises(ParameterBoundError) as exc:
+            self._parser('min').parse_parameter(
+                'grain_duration', 8.0, 0.5, range_unit=RANGE_UNIT_RELATIVE)
+
+        assert '12' in str(exc.value)
+
+    def test_una_banda_che_ci_sta_passa(self):
+        self._parser('min').parse_parameter(
+            'grain_duration', 4.0, 0.5, range_unit=RANGE_UNIT_RELATIVE)
+
+    def test_col_picco_dell_envelope_di_base(self):
+        from pge.shared.exceptions import ParameterBoundError
+
+        with pytest.raises(ParameterBoundError):
+            self._parser('min').parse_parameter(
+                'grain_duration', [[0, 0.01], [4, 9.0]], 0.5,
+                range_unit=RANGE_UNIT_RELATIVE)
+
+    def test_sotto_ancora_center_il_controllo_non_scatta(self):
+        """Storico: con `center` la banda arriva a meta' e la gestisce il clamp."""
+        self._parser('center').parse_parameter(
+            'grain_duration', 8.0, 0.5, range_unit=RANGE_UNIT_RELATIVE)

--- a/tests/parameters/test_range_unit_definitions.py
+++ b/tests/parameters/test_range_unit_definitions.py
@@ -205,3 +205,29 @@ class TestTettoDellaBandaRelativa:
         """Storico: con `center` la banda arriva a meta' e la gestisce il clamp."""
         self._parser('center').parse_parameter(
             'grain_duration', 8.0, 0.5, range_unit=RANGE_UNIT_RELATIVE)
+
+    def test_l_errore_nomina_la_formula_che_ha_applicato(self):
+        """Il messaggio deve dire `base * (1 + range)`, non `base + range`.
+
+        E' l'unico modo che ha il lettore di rifare il conto: chi ha scritto
+        `8.0` e `0.5` e legge «base + range» ottiene 8.5 e non capisce da dove
+        venga il 12 dell'errore. La formula e' la meta' utile del messaggio, e
+        cambia con la modalita': in assoluto resta la somma.
+
+        Si legge su `user_message()`, non su `str()`: `value_type` sta nel
+        corpo strutturato, ed e' quello che la CLI stampa (`cli.py` -> `print(
+        err.user_message())`). Un test su `str()` non vedrebbe la formula
+        nemmeno quando c'e'.
+        """
+        from pge.shared.exceptions import ParameterBoundError
+
+        with pytest.raises(ParameterBoundError) as rel:
+            self._parser('min').parse_parameter(
+                'grain_duration', 8.0, 0.5, range_unit=RANGE_UNIT_RELATIVE)
+        assert 'base * (1 + range)' in rel.value.user_message()
+
+        with pytest.raises(ParameterBoundError) as ass:
+            self._parser('min').parse_parameter(
+                'grain_duration', 9.5, 0.9, range_unit=RANGE_UNIT_ABSOLUTE)
+        assert 'base + range' in ass.value.user_message()
+        assert 'base * (1 + range)' not in ass.value.user_message()

--- a/tests/parameters/test_range_unit_definitions.py
+++ b/tests/parameters/test_range_unit_definitions.py
@@ -137,6 +137,19 @@ class TestParserRangeUnit:
             self._parser().parse_parameter(
                 'volume', 0.0, 12.0, range_unit=RANGE_UNIT_RELATIVE)
 
+    def test_per_il_parser_none_resta_non_dichiarato(self):
+        """La distinzione assente/vuota vive nell'orchestratore, non qui.
+
+        Il parser riceve un valore, non una chiave: `None` e' la firma di ogni
+        chiamante che l'unita' non la prevede nemmeno (create_pitch_parameter,
+        il window controller), quindi qui non puo' essere un errore. Solo chi
+        legge lo YAML sa se quella chiave c'era.
+        """
+        p = self._parser().parse_parameter(
+            'grain_duration', 0.05, 0.01, range_unit=None)
+
+        assert p.get_value(0.0) == pytest.approx(0.05, abs=0.005)
+
     def test_una_grafia_ignota_arriva_attribuita_allo_stream(self):
         with pytest.raises(InvalidFieldValueError) as exc:
             self._parser().parse_parameter(

--- a/tests/parameters/test_range_unit_definitions.py
+++ b/tests/parameters/test_range_unit_definitions.py
@@ -231,3 +231,70 @@ class TestTettoDellaBandaRelativa:
                 'grain_duration', 9.5, 0.9, range_unit=RANGE_UNIT_ABSOLUTE)
         assert 'base + range' in ass.value.user_message()
         assert 'base * (1 + range)' not in ass.value.user_message()
+
+
+# =============================================================================
+# UNA GRAFIA SOLA PER «E' RELATIVO»
+# =============================================================================
+
+class TestUnaSolaGrafiaDelPredicato:
+    """`range_unit_is_relative` deve restare l'unico modo di fare la domanda.
+
+    I lettori sono tre e stanno in tre strati diversi — il pre-normalizzatore
+    delle unita' (`core/stream.py`), l'orchestratore e il parser — e la
+    docstring del predicato lo dichiara. Un `unit == RANGE_UNIT_RELATIVE`
+    scritto a mano è una seconda copia della domanda: oggi risponde uguale, e
+    il giorno che il vocabolario prendesse un alias (come `loop_unit`, dove
+    `seconds` e `absolute` sono la stessa lettura) risponderebbe diverso in un
+    lettore su tre, in silenzio.
+
+    La guardia legge il sorgente come AST, non come testo: un confronto dentro
+    una stringa o un commento non è un confronto.
+    """
+
+    _MODULI = (
+        'pge/parameters/parser.py',
+        'pge/parameters/parameter_orchestrator.py',
+        'pge/core/stream.py',
+    )
+
+    def _confronti_col_letterale(self, path):
+        import ast
+        import pathlib
+
+        src = pathlib.Path(__file__).resolve().parents[2] / 'src' / path
+        albero = ast.parse(src.read_text(encoding='utf-8'))
+
+        def nomina_il_letterale(nodo):
+            return (isinstance(nodo, ast.Name)
+                    and nodo.id == 'RANGE_UNIT_RELATIVE') or (
+                    isinstance(nodo, ast.Attribute)
+                    and nodo.attr == 'RANGE_UNIT_RELATIVE')
+
+        trovati = []
+        for nodo in ast.walk(albero):
+            if not isinstance(nodo, ast.Compare):
+                continue
+            lati = [nodo.left, *nodo.comparators]
+            if any(nomina_il_letterale(lato) for lato in lati):
+                trovati.append(nodo.lineno)
+        return trovati
+
+    @pytest.mark.parametrize('modulo', _MODULI)
+    def test_nessun_confronto_scritto_a_mano(self, modulo):
+        righe = self._confronti_col_letterale(modulo)
+
+        assert righe == [], (
+            f"{modulo}: confronto diretto con RANGE_UNIT_RELATIVE alle righe "
+            f"{righe}. Usa range_unit_is_relative(unit).")
+
+    def test_la_guardia_vede_davvero_un_confronto(self):
+        """La guardia misurata su se stessa: senza, direbbe sempre di sì."""
+        import ast
+
+        albero = ast.parse("x = unit == RANGE_UNIT_RELATIVE\n")
+        compare = [n for n in ast.walk(albero) if isinstance(n, ast.Compare)]
+
+        assert len(compare) == 1
+        assert any(isinstance(l, ast.Name) and l.id == 'RANGE_UNIT_RELATIVE'
+                   for l in [compare[0].left, *compare[0].comparators])

--- a/tests/parameters/test_range_unit_definitions.py
+++ b/tests/parameters/test_range_unit_definitions.py
@@ -207,12 +207,17 @@ class TestTettoDellaBandaRelativa:
             'grain_duration', 8.0, 0.5, range_unit=RANGE_UNIT_RELATIVE)
 
     def test_l_errore_nomina_la_formula_che_ha_applicato(self):
-        """Il messaggio deve dire `base * (1 + range)`, non `base + range`.
+        """Il messaggio deve dire `base + range * |base|`, non `base + range`.
 
         E' l'unico modo che ha il lettore di rifare il conto: chi ha scritto
         `8.0` e `0.5` e legge «base + range» ottiene 8.5 e non capisce da dove
         venga il 12 dell'errore. La formula e' la meta' utile del messaggio, e
         cambia con la modalita': in assoluto resta la somma.
+
+        E' la formula generale, non `base * (1 + range)`: le due coincidono
+        finche' la base e' non negativa, ma la larghezza si misura sul modulo
+        della base (relative_band_width) e il messaggio nomina cio' che il
+        controllo ha davvero calcolato.
 
         Si legge su `user_message()`, non su `str()`: `value_type` sta nel
         corpo strutturato, ed e' quello che la CLI stampa (`cli.py` -> `print(
@@ -224,13 +229,130 @@ class TestTettoDellaBandaRelativa:
         with pytest.raises(ParameterBoundError) as rel:
             self._parser('min').parse_parameter(
                 'grain_duration', 8.0, 0.5, range_unit=RANGE_UNIT_RELATIVE)
-        assert 'base * (1 + range)' in rel.value.user_message()
+        assert 'base + range * |base|' in rel.value.user_message()
 
         with pytest.raises(ParameterBoundError) as ass:
             self._parser('min').parse_parameter(
                 'grain_duration', 9.5, 0.9, range_unit=RANGE_UNIT_ABSOLUTE)
         assert 'base + range' in ass.value.user_message()
-        assert 'base * (1 + range)' not in ass.value.user_message()
+        assert '|base|' not in ass.value.user_message()
+
+
+class TestUnaSolaLetturaDellaBanda:
+    """Il tetto calcolato al parse e la banda pescata a runtime sono la stessa
+    banda, e devono coincidere per costruzione.
+
+    Sono due misure della stessa cosa in due strati diversi — `Parameter` la
+    rifa a ogni grano, il parser una volta sola per sapere se ci sta sotto
+    `max_val` — quindi vanno prese dalla stessa funzione
+    (`relative_band_width`). Scritte separatamente divergevano gia': il tetto
+    era `base * (1 + range)`, che su una base negativa *scende*, mentre la
+    banda sale (la larghezza si misura sul modulo). Il controllo calcolava
+    allora un tetto sotto il pavimento della banda vera e taceva proprio dove
+    doveva parlare, lasciando la parola al safety clamp — un warning per
+    grano, cioe' il sintomo che quel controllo esiste per evitare (vedi la sua
+    docstring).
+
+    `grain_duration` vive sopra lo zero e li' le due formule coincidono: il
+    caso si misura su un dominio con segno, come gia' fa TestBaseConSegno in
+    test_parameter_range_unit.py per la banda a runtime.
+    """
+
+    _SOTTO_ZERO = dict(min_val=-10.0, max_val=-2.0,
+                       min_range=0.0, max_range=1.0,
+                       default_jitter=0.0, variation_mode='additive')
+
+    def _parse(self, base, frazione):
+        from pge.core.stream_config import StreamConfig, StreamContext
+        from pge.parameters.parameter_definitions import ParameterBounds
+        from pge.parameters.parser import GranularParser
+
+        ctx = StreamContext(stream_id='s1', onset=0.0, duration=4.0,
+                            sample='x.wav', sample_dur_sec=10.0)
+        parser = GranularParser(StreamConfig(context=ctx, range_anchor='min'))
+        return parser.parse_parameter(
+            'volume', base, frazione,
+            bounds_override=ParameterBounds(**self._SOTTO_ZERO),
+            range_unit=RANGE_UNIT_RELATIVE)
+
+    def test_su_base_negativa_il_tetto_e_quello_della_banda_vera(self):
+        """base -6, frazione 1.0: la banda arriva a 0, il tetto e' -2.
+
+        Col prodotto il controllo calcolava -12 — sotto il pavimento della
+        banda — e passava in silenzio.
+        """
+        from pge.shared.exceptions import ParameterBoundError
+
+        with pytest.raises(ParameterBoundError) as exc:
+            self._parse(-6.0, 1.0)
+
+        assert '0' in str(exc.value)
+
+    def test_una_banda_che_ci_sta_passa_anche_sotto_zero(self):
+        """base -6, frazione 0.5: la banda arriva a -3, sotto il tetto -2."""
+        self._parse(-6.0, 0.5)
+
+    def test_il_tetto_al_parse_copre_i_draw(self):
+        """La misura che lega i due strati: nessun grano esce dal tetto.
+
+        Senza clamp di mezzo — il tetto dichiarato sta dentro i bounds — il
+        massimo pescato non puo' superare quello che il parse aveva promesso.
+        """
+        from pge.shared.probability_gate import AlwaysGate
+        from pge.parameters.parameter_definitions import relative_band_width
+
+        p = self._parse(-6.0, 0.5)
+        p.set_probability_gate(AlwaysGate())
+
+        tetto = -6.0 + relative_band_width(0.5, -6.0)
+        draws = [p.get_value(0.0) for _ in range(400)]
+
+        assert max(draws) <= tetto + 1e-9
+        assert max(draws) > -6.0          # la banda sale davvero
+        assert min(draws) >= -6.0 - 1e-9
+
+
+class TestLarghezzaRelativa:
+    """`relative_band_width` e' la grafia unica della larghezza."""
+
+    def test_e_la_frazione_del_modulo_della_base(self):
+        from pge.parameters.parameter_definitions import relative_band_width
+
+        assert relative_band_width(0.5, 10.0) == pytest.approx(5.0)
+        assert relative_band_width(0.5, -10.0) == pytest.approx(5.0)
+        assert relative_band_width(0.0, 10.0) == 0.0
+        assert relative_band_width(0.5, 0.0) == 0.0
+
+    @pytest.mark.parametrize('modulo', (
+        'pge/parameters/parameter.py',
+        'pge/parameters/parser.py',
+    ))
+    def test_i_due_lettori_la_chiamano_invece_di_riscriverla(self, modulo):
+        """Guardia AST: entrambi gli strati passano dalla stessa funzione.
+
+        Gemella di TestUnaSolaGrafiaDelPredicato: li' il predicato, qui la
+        larghezza. Una moltiplicazione riscritta a mano in uno dei due
+        risponderebbe uguale finche' la base resta positiva, e diverso — in
+        silenzio — il giorno che non lo e'.
+        """
+        import ast
+        import pathlib
+
+        src = pathlib.Path(__file__).resolve().parents[2] / 'src' / modulo
+        albero = ast.parse(src.read_text(encoding='utf-8'))
+
+        chiamate = [
+            n for n in ast.walk(albero)
+            if isinstance(n, ast.Call)
+            and ((isinstance(n.func, ast.Name)
+                  and n.func.id == 'relative_band_width')
+                 or (isinstance(n.func, ast.Attribute)
+                     and n.func.attr == 'relative_band_width'))
+        ]
+
+        assert chiamate, (
+            f"{modulo}: la larghezza della banda relativa non passa piu' da "
+            "relative_band_width()")
 
 
 # =============================================================================

--- a/tests/parameters/test_range_unit_definitions.py
+++ b/tests/parameters/test_range_unit_definitions.py
@@ -75,6 +75,27 @@ class TestDominioDellaFrazione:
         assert relativo.default_jitter == assoluto.default_jitter
         assert relativo.variation_mode == assoluto.variation_mode
 
+    def test_sostituisce_il_dominio_invece_di_restringerlo(self):
+        """«Sostituisce, non restringe» misurato dove le due letture divergono.
+
+        Nessun parametro del registry sa discriminarle: `min_range` e' 0.0 su
+        tutti — cioe' gia' `RELATIVE_RANGE_BOUNDS[0]` — e nessun `max_range`
+        cade in `(0, 1)`, quindi su `volume` (24) come su `grain_duration` (1)
+        un `min` fra i due domini risponde come una sostituzione. Il test che
+        misura su `volume` sfugge alla coincidenza dei due `1` di
+        `grain_duration` ma ricade in quella del pavimento, che e' 0.0
+        ovunque: servono bounds sintetici, che sono l'unico posto dove la
+        differenza si vede.
+        """
+        from pge.parameters.parameter_definitions import ParameterBounds
+
+        stretto = ParameterBounds(min_val=0.0, max_val=1.0,
+                                  min_range=0.2, max_range=0.4)
+
+        relativo = relative_range_bounds(stretto)
+
+        assert (relativo.min_range, relativo.max_range) == RELATIVE_RANGE_BOUNDS
+
     def test_convive_col_minimo_dinamico_di_grain_duration(self):
         """Il pavimento di 1 campione non deve sparire sotto la sostituzione."""
         dinamico = get_parameter_definition('grain_duration', output_sr=48000)
@@ -149,6 +170,30 @@ class TestParserRangeUnit:
             'grain_duration', 0.05, 0.01, range_unit=None)
 
         assert p.get_value(0.0) == pytest.approx(0.05, abs=0.005)
+
+    def test_il_dominio_relativo_vale_anche_sui_bounds_override(self):
+        """La sostituzione e' un fatto della modalita', non della provenienza.
+
+        `parse_parameter` lo dichiara in un commento («override compreso»), e
+        nessun test lo misurava: l'unico che passa un `bounds_override` insieme
+        a `relative` (TestUnaSolaLetturaDellaBanda) ci scrive dentro a mano il
+        dominio frazionario, quindi non puo' vedere se la sostituzione e'
+        avvenuta. Qui l'override porta il dominio di `volume` (24 dB): una
+        frazione di 5.0 ci starebbe, e nel dominio della modalita' no.
+        """
+        from pge.parameters.parameter_definitions import ParameterBounds
+        from pge.shared.exceptions import ParameterBoundError
+
+        largo = ParameterBounds(min_val=-120.0, max_val=12.0,
+                                min_range=0.0, max_range=24.0)
+
+        self._parser().parse_parameter(          # assoluto: 5.0 dB ci stanno
+            'volume', -6.0, 5.0, bounds_override=largo)
+
+        with pytest.raises(ParameterBoundError):
+            self._parser().parse_parameter(
+                'volume', -6.0, 5.0, bounds_override=largo,
+                range_unit=RANGE_UNIT_RELATIVE)
 
     def test_una_grafia_ignota_arriva_attribuita_allo_stream(self):
         with pytest.raises(InvalidFieldValueError) as exc:


### PR DESCRIPTION
Chiude #267.

## Il problema

`grain.duration_range` era una banda **assoluta**, nell'unità di `duration_unit`.
Dove `grain.duration` è un asse che spazia su più ordini di grandezza — lo studio
da cui la issue nasce va da 1 campione (~0.021 ms) a 500 ms — la stessa banda è
molte volte la durata sui grani corti (dove poi il clamp a 1 campione la taglia) e
percentualmente trascurabile sui lunghi. Il *carattere* della dispersione cambia
da solo lungo lo sweep, pur non avendo mosso `duration_range`, e all'ascolto
l'effetto dell'asse si confonde con l'effetto collaterale del range.

## La superficie

Chiave dedicata, default retrocompatibile:

```yaml
grain:
  duration_unit: milliseconds
  duration: [[0, 0.021], [60, 500]]
  duration_range: 0.5
  duration_range_unit: relative      # "absolute" (default) | "relative"
```

`0.5` è ±25% della durata corrente: a 1 ms come a 500 ms. È l'opzione 1 delle due
proposte nella issue; la seconda (un valore in più su `duration_unit`) resta
scartata perché `duration_unit` governa anche la base, che relativa non ha senso.

## Le tre decisioni non ovvie

**Il dominio della frazione è `[0, 1]`**, e non è quello del parametro: è proprio
della modalità (`RELATIVE_RANGE_BOUNDS`), e lo **sostituisce** invece di
restringerlo. Che coincida numericamente col `max_range` assoluto di
`grain_duration` è un caso — su `volume` i due divergono (24 dB contro 1.0), e i
test lo misurano lì proprio per questo. Le due ancore consumano quel dominio in
modi diversi, e la differenza va detta:

| `range_anchor` | banda con frazione `r` | massimo a `r = 1` |
|---|---|---|
| `center` | `[base·(1 − r/2), base·(1 + r/2)]` | ±50% |
| `min` | `[base, base·(1 + r)]` | +100% |

Sotto `center` il pavimento è `base·(1 − r/2)` e quindi **si muove con la base**
invece di restare fermo dove lo mette una banda assoluta: è la ragione per cui la
modalità esiste. Non è però una garanzia di stare sopra il minimo del parametro,
che resta fisso: il pavimento ci finisce sotto appena `base < min_val / (1 − r/2)`
— per `grain_duration`, con `r = 1`, sotto i 2 campioni, cioè l'estremo esatto
dello sweep da cui l'issue nasce. Lì torna a parlare il safety clamp, e `yaml.md`
lo dichiara con la sua condizione invece che in assoluto. Il tetto del dominio è
widenable in seguito senza rompere niente (allargare un dominio è
retrocompatibile, stringerlo no) — e perché resti vero è servito il quarto giro
di review, vedi sotto.

**Il tetto al parse sotto `range_anchor: min` smette di sommare.**
`base + range` sommava una frazione a una durata: con `base: 8` s e frazione
`0.5` dava 8.5, sotto il tetto di 10 s, mentre la banda arriva davvero a 12.
Lasciava passare in silenzio proprio le bande larghe. Ora il tetto è
`base + range · |base|` — su una base positiva, `base · (1 + range)` — e viene
dalla stessa funzione (`relative_band_width`) che il `Parameter` chiama a ogni
grano: il tetto al parse e la banda a runtime sono due letture della stessa
banda, e coincidono per costruzione. Su una base envelope si misura su **ogni**
breakpoint e non sul solo picco. Vedi i giri di review in fondo.

**`duration_unit` non converte una frazione.** Era il modo peggiore di
sbagliare, perché muto: `duration_range: 0.5` sotto `duration_unit: samples`
sarebbe diventato `0.5/48000` e la variazione sarebbe sparita senza un errore
né un warning da leggere nel file. Il test rosso di quello slice lo ha
riprodotto prima della guardia.

## Due errori nuovi, e perché

Tutti e due chiudono la stessa forma di difetto: una riga scritta nel file che
nessuno legge, senza niente nel file da cui accorgersene.

`duration_range_unit: relative` **senza** `duration_range` è un
`MissingFieldError` al parse, non una chiave inerte: al posto della banda
subentrerebbe il jitter implicito, che è assoluto (0.01 s) — cioè, su grani da
un campione, esattamente la patologia che la issue denuncia, con l'utente
convinto di aver attivato il relativo. Stessa regola con cui `duration_unit:
samples` pretende una `duration` esplicita.

`duration_range_unit:` **scritta e lasciata vuota** è `InvalidFieldValueError`,
non il default assoluto. Assente e vuota non vogliono dire la stessa cosa:
assente è nessuna richiesta, vuota è una riga che qualcuno ha scritto. La
distinzione richiede una sentinella nell'orchestratore, perché
`resolve_yaml_path` restituisce il default per entrambe; la gemella
`grain.duration_unit` una grafia vuota la rifiuta già.

## Architettura

Il meccanismo è dichiarativo — `ParameterSpec.range_unit_path` — ma cablato oggi
sul solo `grain.duration_range`: è l'unico parametro la cui base spazia per
costruzione da 1 campione a 10 secondi, mentre su `volume` (dB) e `pan` (gradi)
la scala è già logaritmica o ciclica e una frazione della base non direbbe la
stessa cosa. Un test lo fissa: oggi `range_unit_path` lo dichiara un solo spec.

Da non confondere con `pointer.offset_range`, che è relativo per costruzione e
per un altro meccanismo (frazione della finestra di loop, non del proprio valore
base — che non ha).

La lettura della chiave sta nell'orchestratore e non nel parser perché lì si
conoscono i due path YAML: quello dell'unità, per nominarla in un errore di
vocabolario, e quello del range, per nominare la chiave che manca. Il parser
riceve un valore, non una chiave, e non può nemmeno distinguere una chiave
assente da una vuota — per questo `None` lì resta «unità non dichiarata».

`VARIATION_SEMANTICS_VERSION` **non si muove**: a chiave assente la lettura è
identica a prima, quindi nessuno stem esistente diventa dirty. Il verso opposto
è misurato dal settimo giro: uno stem che la chiave la usa diventa dirty quando
la chiave cambia, perché il fingerprint filtra solo `{solo, mute}` al primo
livello e questa vive annidata sotto `grain`.

## File toccati

| Path | Cosa |
|---|---|
| `src/pge/parameters/parameter.py` | `range_relative`: la banda è `frazione × base`, calcolata dopo l'envelope della base |
| `src/pge/parameters/parameter_definitions.py` | `RANGE_UNITS`, `RELATIVE_RANGE_BOUNDS`, `validate_range_unit`, `relative_range_bounds`, `relative_band_width` |
| `src/pge/parameters/parameter_schema.py` | `ParameterSpec.range_unit_path` + il cablaggio di `grain_duration` |
| `src/pge/parameters/parameter_orchestrator.py` | lettura, validazione, chiave vuota e `MissingFieldError` |
| `src/pge/parameters/parser.py` | dominio, modalità e formula del tetto |
| `src/pge/core/stream.py` | `duration_unit` non scala una frazione |
| `docs/reference/yaml.md`, `docs/how-to/add-parameter.md`, `CHANGELOG.md` | documentazione |
| `docs/explanation/parameter-curve.md` | la faccia `range` è il valore dichiarato (sesto giro) |
| `.claude/rules/cross-repo-impact.md`, `CLAUDE.md` | la regola cross-repo conosceva due consumer su tre (quinto giro) |

## Test

`make tests`: **6905 passed, 18 skipped** dopo l'allineamento a `main` (il branch
da solo dava 6431 passed, 10 skipped su una baseline di 6362 — 69 nuovi; il resto
arriva da `main`, #202, #177 e #178). TDD a slice verticali, ogni slice rosso
prima di essere verde.

- `tests/parameters/test_parameter_range_unit.py` — la banda dentro `Parameter`: frazione della base, base envelope, frazione envelope, ancora `min`, jitter implicito che resta assoluto, base con segno, la firma che pretende la base, la faccia `range` che pubblica il dichiarato
- `tests/parameters/test_range_unit_definitions.py` — vocabolario, dominio (misurato su `volume`, dove diverge), parser, tetto, l'invariante che tetto al parse e banda a runtime sono una lettura sola, che il tetto non assume la monotonia nella base, e il censimento — derivato dall'albero, non scritto a mano — della grafia unica del predicato
- `tests/parameters/test_grain_duration_range_unit.py` — dallo YAML allo spec, gli errori, la chiave vuota contro la chiave assente, l'unico spec cablato
- `tests/core/test_grain_duration_range_relative.py` — i grani generati, incluso il test che misura che **la dispersione relativa resta costante** lungo uno sweep di due ordini di grandezza, la convivenza con `duration_unit: samples | milliseconds` e la soglia sotto cui il pavimento torna al clamp

## Giri di review

**Terzo giro** — due difetti, `870bd6f` e `38bce47`.

*Il tetto della banda era una seconda lettura, e divergeva.* `_validate_band_ceiling`
scriveva `base * (1 + range)`, `Parameter._calculate_range` scriveva
`range * abs(base)`: su una base negativa le due dicono il contrario — il
prodotto scende sotto la base, la banda sale sopra — e il controllo calcolava un
tetto *sotto* il pavimento della banda vera, tacendo proprio dove doveva parlare
e lasciando la parola al safety clamp, cioè al warning per grano che quel
controllo esiste per evitare. La larghezza ha ora una grafia sola,
`relative_band_width(frazione, base)`, con una guardia AST che tiene entrambi gli
strati sulla funzione. Nello stesso commit `_calculate_range` perde il default su
`base_val`: in modalità assoluta la base non entra nel conto, ed è proprio per
questo che il default era pericoloso — dimenticarlo non si vedeva finché qualcuno
non dichiarava `relative`, dove la banda sarebbe valsa `frazione * 0`.

*La tabella bounds diceva il contrario del codice*, annotando che `relative`
cambia il significato del numero e non il dominio, mentre `RELATIVE_RANGE_BOUNDS`
si dichiara un dominio proprio della modalità che **sostituisce** quello del
parametro.

**Quarto giro** — tre difetti, `38c67de`, `3184cb4`, `e42ed72`.

*Il tetto assumeva la monotonia nella base.* Valutato nel solo picco della base,
il tetto è il massimo vero solo se `f(base) = base + r·|base|` cresce con la
base: sopra lo zero sempre, sotto lo zero solo finché `r ≤ 1`. Reggeva quindi su
`RELATIVE_RANGE_BOUNDS[1] <= 1`, che nessuna riga dichiarava load-bearing e che
questa descrizione annuncia come libero di muoversi. Ora il tetto si misura su
ogni base candidata: costa un `max` su breakpoint già letti e toglie
l'assunzione.

*«Sostituisce, non restringe» non lo misurava nessun test*: tre mutazioni di
`relative_range_bounds` (pavimento non sostituito, `min` invece di sostituzione,
sostituzione saltata sotto `bounds_override`) sopravvivevano, perché nel registry
nessun parametro ha `min_range != 0` e nessun `max_range` cade in `(0, 1)`.
Servivano bounds sintetici.

*La `duration` esplicita la pretende la base, non il range*: il commento che
giustifica il `MissingFieldError` su `grain.duration` invocava ancora «altrimenti
base e range finiscono in domini diversi», argomento che questa PR rende falso in
un ramo su due. Il vincolo resta giusto, ma per un'altra ragione — il default
`0.05` è in secondi.

**Quinto giro** — [`d06e368`](https://github.com/DMGiulioRomano/PythonGranularEngine/commit/d06e368).

*L'analisi d'impatto cross-repo conosceva due consumer su tre.* La issue #267
nomina `gl-ls` fra gli impatti attesi, e i primi quattro giri non potevano
accorgersene: `.claude/rules/cross-repo-impact.md` elencava PGE-ls e PGE-ui, e
l'elenco che dice chi guardare è anche l'unico posto che dice chi non guardare.
gl-ls non è un terzo lettore della stessa superficie — mirrora codice PGE invece
di leggerlo dal vivo (registry di chiavi con `grain` a vocabolario **chiuso**,
più `diagnostics._UNIT_SCALED`, gemello di `_pre_normalize_grain_params`), quindi
una chiave nuova dentro un blocco engine è subito un falso rosso su YAML valido.
Misurato e aperto come [DMGiulioRomano/gl-ls#49](https://github.com/DMGiulioRomano/gl-ls/issues/49).
Nello stesso commit, `yaml.md`: l'esempio canonico della sezione era annotato
«tre ordini di grandezza» ed è un fattore 23800.

**Sesto giro** — [`e479944`](https://github.com/DMGiulioRomano/PythonGranularEngine/commit/e479944), [`c3b9ce4`](https://github.com/DMGiulioRomano/PythonGranularEngine/commit/c3b9ce4).

*Il branch non era più mergiabile, e nessuno dei cinque giri poteva vederlo:*
tutti hanno girato la suite sul branch da solo, mentre `main` avanzava di 40
commit (#202 catalogo finestre, #177 doc del registry, #263, #264). Il CHANGELOG
confliggeva in testa a «Non rilasciato», dove i due lati hanno inserito la
propria voce. Risolto tenendo entrambe le voci; le due superfici sono disgiunte —
`main` ha toccato solo il sottosistema finestre — e la suite unita lo conferma.

*La faccia `range` lo diceva a un consumatore su due.* `range_curve` pubblica la
frazione e non la larghezza: detto nella docstring e in `yaml.md`, ma lì la frase
era «**In partitura**», e i consumatori della faccia sono due. L'altro è
`SVExporter`, dove la stessa curva diventa un layer
`<stream_id>/grain_duration_range` dentro una sessione Sonic Visualiser salvata
su disco — la vista che sopravvive al render, e dove un cursore di misura legge
`0.5` come mezzo secondo. E `docs/explanation/parameter-curve.md`, il doc che
*definisce* le tre facce e che ha `parameters/parameter.py` fra i propri
`sources`, la chiamava «deviazione per-grano» e basta: dei tre posti che parlano
della faccia, l'unico che la possiede era l'unico muto. Scelta di progetto
invariata, ora misurata (`TestLaFacciaRangePubblicaLaFrazione`) invece che
scritta in prosa in tre punti liberi di divergere.

**Settimo giro** — [`37b2066`](https://github.com/DMGiulioRomano/PythonGranularEngine/commit/37b2066), [`4f10156`](https://github.com/DMGiulioRomano/PythonGranularEngine/commit/4f10156).

*Il branch non era di nuovo mergiabile, e la correzione del sesto giro scadeva
per costruzione.* `main` ha assorbito #178 (contratto di stdout) e il CHANGELOG
confliggeva **di nuovo** nello stesso punto. La seconda occorrenza dice una cosa
che la prima non diceva: non è un incidente, è la forma del file — finché
«Non rilasciato» ha un solo punto d'inserimento e `main` si muove, ogni giro che
non sia l'ultimo trova quel conflitto. Superfici di nuovo disgiunte (#178 tocca
`shared/logger.py`, `api.py` e la doc del contratto), e la sua guardia — che
classifica ogni `print()` di `src/pge/` — è pertinente proprio qui: questa PR non
ne aggiunge nessuna, gli errori si alzano e il clamp passa dal logger.

*Il censimento della grafia unica era lui stesso una seconda copia.* I sei giri
hanno misurato il codice con le guardie; nessuno ha misurato le guardie.
`TestUnaSolaGrafiaDelPredicato` fa la domanda giusta — `range_unit_is_relative`
deve restare l'unico modo di chiedere «è relativo?» — ma la faceva a tre moduli
**scritti a mano nel test**, cioè alla seconda copia della cosa stessa che la
guardia impedisce, muta esattamente il giorno che nasce un quarto lettore.
Misurato: un `unit == RANGE_UNIT_RELATIVE` piantato in
`rendering/envelope_extractor.py` lasciava la guardia verde. Ora il censimento è
derivato dall'albero — ogni `.py` sotto `src/pge/` — con una sola esenzione
dichiarata per nome, il modulo che il letterale lo possiede e dove il confronto
*è* la definizione del predicato. Due test tengono in piedi esenzione e
censimento: che il proprietario il confronto ce l'abbia davvero (uno solo), e che
l'elenco non sia vuoto — un `rglob` a vuoto renderebbe verde per vacuità tutto il
resto della classe.

Nello stesso giro, verificato e senza azione: il fuzz differenziale del tetto
(4000 configurazioni sotto ancora `min`, zero violazioni in **entrambe** le
direzioni — nessuna banda che passa il controllo e sfora, nessun falso positivo);
che il `Parameter` non attraversi mai il pickle, quindi `range_relative` non può
perdersi nel rendering multi-processo; e il verso non verificato della claim sul
fingerprint, ora misurato.

## Impatto cross-repo

- PGE-ls: [DMGiulioRomano/PGE-ls#50](https://github.com/DMGiulioRomano/PGE-ls/issues/50) — `schema_bridge.py` non legge `ParameterSpec.range_unit_path`.
- PGE-ui: [DMGiulioRomano/PGE-ui#163](https://github.com/DMGiulioRomano/PGE-ui/issues/163) — `convertGrainDurationUnit` convertirebbe la frazione, scrivendo nel file lo stesso `0.5/48000` muto che questa PR guarda dal lato motore.
- gl-ls: [DMGiulioRomano/gl-ls#49](https://github.com/DMGiulioRomano/gl-ls/issues/49) — `unknown-key` su YAML valido con un quick fix distruttivo, `_UNIT_SCALED` che mirrora una conversione che l'engine non fa più, e l'hover della banda in `±s`.

Sul paper CIM 2026: **nessun impatto**. La chiave è opt-in con default
`absolute`, nessun esempio `exN.yml` la usa, e a chiave assente il rendering è
bit per bit quello di prima — niente bump del submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013h2E1SXJV5apTAqYfGrdJe